### PR TITLE
feat: track key optionality (presence vs parent count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ schermz -m -f ./sample.json
     "types": [
       {
         "age": {
+          "optional": true,
           "types": [
             "NUMBER"
           ]
@@ -105,6 +106,38 @@ schermz -m -f ./sample.json
 }
 
 ```
+
+Note `age` is annotated `"optional": true` — it was present on Martin but
+not on Paul. See [Optional fields](#optional-fields) below.
+
+## Optional fields
+
+For every key, schermz reports whether it appeared in 100% of the observed
+parent objects of its enclosing shape. When a key is *not* always present, it
+gets `"optional": true`. Always-present keys carry no annotation, which keeps
+the output tight.
+
+This matters for codegen: it's the difference between `field: T` and
+`field?: T` in TypeScript, or `z.string()` and `z.string().optional()` in Zod.
+
+The denominator depends on context:
+
+- For top-level keys, it's the number of objects in the input array (or 1 for
+  a single-object input — schermz can't infer optionality from a sample size
+  of 1, so nothing is ever marked optional in that case).
+- For nested object keys, it's the number of parents that had this key set to
+  an object of this shape.
+- For object keys inside arrays, it's the total number of object elements
+  observed across all parent arrays.
+
+Without `-m`, distinct object shapes for the same key are listed separately.
+Within any one variant, all objects by definition share the same keys, so
+`optional` won't appear. Use `-m` to flatten variants and reveal which keys
+are sometimes-present in the merged shape.
+
+A key whose value is `null` still counts as "present" for this signal —
+`{ "x": null }` is different from `{}`. The `null` shows up inside `types`,
+not in the optionality flag.
 
 ## Output
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -63,8 +63,15 @@ impl SchemaValueType {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+struct KeyEntry {
+    types: Vec<SchemaValueType>,
+    seen_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Schema {
-    pub map: HashMap<String, Vec<SchemaValueType>>,
+    parent_count: usize,
+    map: HashMap<String, KeyEntry>,
 }
 
 type CollectedObjects = HashMap<String, Vec<SchemaObject>>;
@@ -89,11 +96,9 @@ impl Schema {
             .collect()
     }
 
-    fn create_map(
-        objects: Vec<SchemaObject>,
-        merge_objects: bool,
-    ) -> HashMap<String, Vec<SchemaValueType>> {
-        let mut map = HashMap::<String, Vec<SchemaValueType>>::new();
+    fn create_map(objects: Vec<SchemaObject>, merge_objects: bool) -> HashMap<String, KeyEntry> {
+        let mut types_map = HashMap::<String, Vec<SchemaValueType>>::new();
+        let mut seen_counts = HashMap::<String, usize>::new();
         let mut string_lens = HashMap::<String, Vec<usize>>::new();
         let mut object_types = CollectedObjects::new();
         let mut array_object_types = CollectedObjects::new();
@@ -102,6 +107,7 @@ impl Schema {
 
         for obj in objects {
             for key in &obj.keys {
+                *seen_counts.entry(key.id.clone()).or_insert(0) += 1;
                 match &key.v_type {
                     ValueType::Object(obj) => {
                         object_types
@@ -143,7 +149,7 @@ impl Schema {
                         string_lens.entry(key.id.clone()).or_default().push(*len);
                     }
                     primitive_type => {
-                        let entry = map.entry(key.id.clone()).or_default();
+                        let entry = types_map.entry(key.id.clone()).or_default();
                         let vtype = SchemaValueType::from_value_type(primitive_type, merge_objects);
                         if !entry.contains(&vtype) {
                             entry.push(vtype);
@@ -156,19 +162,22 @@ impl Schema {
         for (key, lens) in string_lens {
             let min = *lens.iter().min().unwrap();
             let max = *lens.iter().max().unwrap();
-            map.entry(key)
+            types_map
+                .entry(key)
                 .or_default()
                 .push(SchemaValueType::String(min, max));
         }
 
         for (key, value) in object_types {
             if merge_objects {
-                map.entry(key)
+                types_map
+                    .entry(key)
                     .or_default()
                     .push(SchemaValueType::Object(Schema::from_objects(value, true)));
             } else {
                 for objects_group in Self::group_objects_by_keys_fingerprint(value) {
-                    map.entry(key.clone())
+                    types_map
+                        .entry(key.clone())
                         .or_default()
                         .push(SchemaValueType::Object(Schema::from_objects(
                             objects_group,
@@ -207,16 +216,25 @@ impl Schema {
                 let max = *string_lens.iter().max().unwrap();
                 all_array_types.push(SchemaValueType::String(min, max));
             }
-            map.entry(key)
+            types_map
+                .entry(key)
                 .or_default()
                 .push(SchemaValueType::Array(all_array_types));
         }
 
-        map
+        types_map
+            .into_iter()
+            .map(|(key, types)| {
+                let seen_count = seen_counts.remove(&key).unwrap_or(0);
+                (key, KeyEntry { types, seen_count })
+            })
+            .collect()
     }
 
     fn from_objects(objects: Vec<SchemaObject>, merge_objects: bool) -> Self {
+        let parent_count = objects.len();
         Self {
+            parent_count,
             map: Self::create_map(objects, merge_objects),
         }
     }
@@ -224,11 +242,14 @@ impl Schema {
     pub fn to_json(&self) -> JsonValue {
         let mut map = serde_json::Map::new();
 
-        for (key, value) in &self.map {
-            let mut entry = serde_json::Map::new();
-            let types: Vec<JsonValue> = value.iter().map(SchemaValueType::to_json).collect();
-            entry.insert("types".into(), JsonValue::Array(types));
-            map.insert(key.clone(), JsonValue::Object(entry));
+        for (key, entry) in &self.map {
+            let mut out = serde_json::Map::new();
+            let types: Vec<JsonValue> = entry.types.iter().map(SchemaValueType::to_json).collect();
+            out.insert("types".into(), JsonValue::Array(types));
+            if entry.seen_count < self.parent_count {
+                out.insert("optional".into(), JsonValue::Bool(true));
+            }
+            map.insert(key.clone(), JsonValue::Object(out));
         }
 
         JsonValue::Object(map)

--- a/src/schema/snapshots/schermz__schema__tests__array_of_objects_optional_field.snap
+++ b/src/schema/snapshots/schermz__schema__tests__array_of_objects_optional_field.snap
@@ -1,0 +1,28 @@
+---
+source: src/schema/tests.rs
+assertion_line: 368
+expression: "Schema::from_json(&json, true).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "a": {
+              "types": [
+                "NUMBER"
+              ]
+            },
+            "b": {
+              "optional": true,
+              "types": [
+                "NUMBER"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__nested_object_optional_uses_correct_denominator.snap
+++ b/src/schema/snapshots/schermz__schema__tests__nested_object_optional_uses_correct_denominator.snap
@@ -1,24 +1,31 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 113
+assertion_line: 344
 expression: "Schema::from_json(&json, true).to_json()"
 ---
 {
-  "info": {
+  "addr": {
+    "optional": true,
     "types": [
       {
-        "a": {
+        "x": {
           "types": [
             "NUMBER"
           ]
         },
-        "b": {
+        "y": {
           "optional": true,
           "types": [
             "NUMBER"
           ]
         }
       }
+    ]
+  },
+  "other": {
+    "optional": true,
+    "types": [
+      "NUMBER"
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__null_value_counts_as_present.snap
+++ b/src/schema/snapshots/schermz__schema__tests__null_value_counts_as_present.snap
@@ -1,0 +1,20 @@
+---
+source: src/schema/tests.rs
+assertion_line: 380
+expression: "Schema::from_json(&json, false).to_json()"
+---
+{
+  "x": {
+    "optional": true,
+    "types": [
+      "NUMBER",
+      "NULL"
+    ]
+  },
+  "y": {
+    "optional": true,
+    "types": [
+      "NUMBER"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__optional_top_level_key_in_array.snap
+++ b/src/schema/snapshots/schermz__schema__tests__optional_top_level_key_in_array.snap
@@ -1,0 +1,18 @@
+---
+source: src/schema/tests.rs
+assertion_line: 325
+expression: "Schema::from_json(&json, false).to_json()"
+---
+{
+  "a": {
+    "types": [
+      "NUMBER"
+    ]
+  },
+  "b": {
+    "optional": true,
+    "types": [
+      "NUMBER"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__schema_from_array_merged.snap
+++ b/src/schema/snapshots/schermz__schema__tests__schema_from_array_merged.snap
@@ -1,5 +1,6 @@
 ---
-source: src/schema.rs
+source: src/schema/tests.rs
+assertion_line: 223
 expression: "Schema::from_json(&json, true).to_json()"
 ---
 {
@@ -13,16 +14,19 @@ expression: "Schema::from_json(&json, true).to_json()"
           ]
         },
         "country": {
+          "optional": true,
           "types": [
             "STRING(3, 7)"
           ]
         },
         "country_code": {
+          "optional": true,
           "types": [
             "STRING(2)"
           ]
         },
         "state": {
+          "optional": true,
           "types": [
             "STRING(10, 11)"
           ]
@@ -60,6 +64,7 @@ expression: "Schema::from_json(&json, true).to_json()"
           ]
         },
         "marital_status": {
+          "optional": true,
           "types": [
             "STRING(6, 7)"
           ]
@@ -74,6 +79,7 @@ expression: "Schema::from_json(&json, true).to_json()"
         "ARRAY": [
           {
             "fax": {
+              "optional": true,
               "types": [
                 "STRING(13)"
               ]

--- a/src/schema/snapshots/schermz__schema__tests__single_object_input_never_marks_optional.snap
+++ b/src/schema/snapshots/schermz__schema__tests__single_object_input_never_marks_optional.snap
@@ -1,0 +1,17 @@
+---
+source: src/schema/tests.rs
+assertion_line: 332
+expression: "Schema::from_json(&json, false).to_json()"
+---
+{
+  "a": {
+    "types": [
+      "NUMBER"
+    ]
+  },
+  "b": {
+    "types": [
+      "NUMBER"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__type_variation_alone_is_not_optionality.snap
+++ b/src/schema/snapshots/schermz__schema__tests__type_variation_alone_is_not_optionality.snap
@@ -1,0 +1,13 @@
+---
+source: src/schema/tests.rs
+assertion_line: 391
+expression: "Schema::from_json(&json, false).to_json()"
+---
+{
+  "id": {
+    "types": [
+      "NUMBER",
+      "STRING(3)"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__unmerged_variants_have_no_optional_within.snap
+++ b/src/schema/snapshots/schermz__schema__tests__unmerged_variants_have_no_optional_within.snap
@@ -1,0 +1,30 @@
+---
+source: src/schema/tests.rs
+assertion_line: 355
+expression: "Schema::from_json(&json, false).to_json()"
+---
+{
+  "addr": {
+    "types": [
+      {
+        "x": {
+          "types": [
+            "NUMBER"
+          ]
+        },
+        "y": {
+          "types": [
+            "NUMBER"
+          ]
+        }
+      },
+      {
+        "x": {
+          "types": [
+            "NUMBER"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -311,3 +311,82 @@ fn test_schema_from_array_unmerged() {
 
     insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
 }
+
+// ---------- Feature 1: optionality tracking ----------
+
+#[test]
+fn optional_top_level_key_in_array() {
+    // `b` is missing from one of three parents -> optional. `a` always present.
+    let json = serde_json::json!([
+        { "a": 1 },
+        { "a": 2, "b": 20 },
+        { "a": 3 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+}
+
+#[test]
+fn single_object_input_never_marks_optional() {
+    // Sample size of 1 -> we can't infer optionality.
+    let json = serde_json::json!({ "a": 1, "b": 2 });
+    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+}
+
+#[test]
+fn nested_object_optional_uses_correct_denominator() {
+    // outer "addr" is present in 2/3 parents (one entry has no addr at all).
+    // Within addr (merged), "x" is in both, "y" only in one.
+    let json = serde_json::json!([
+        { "addr": { "x": 1, "y": 2 } },
+        { "addr": { "x": 1 } },
+        { "other": 1 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+}
+
+#[test]
+fn unmerged_variants_have_no_optional_within() {
+    // Without -m each variant shape contains by definition only objects with
+    // identical keys, so no key is ever optional within a variant.
+    let json = serde_json::json!([
+        { "addr": { "x": 1, "y": 2 } },
+        { "addr": { "x": 1 } }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+}
+
+#[test]
+fn array_of_objects_optional_field() {
+    // The merged shape inside `items[]` should mark `b` as optional because
+    // only one of the two array elements (across all parents) had it.
+    let json = serde_json::json!({
+        "items": [
+            { "a": 1 },
+            { "a": 2, "b": 20 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+}
+
+#[test]
+fn null_value_counts_as_present() {
+    // {x: null} is "x is present" — different from {} (x missing).
+    // x: 2/3, y: 1/3 -> both optional, but x is *seen* in 2 parents not 1.
+    let json = serde_json::json!([
+        { "x": 1 },
+        { "x": null },
+        { "y": 7 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+}
+
+#[test]
+fn type_variation_alone_is_not_optionality() {
+    // Same key in every parent, just with different scalar types.
+    let json = serde_json::json!([
+        { "id": 1 },
+        { "id": "two" },
+        { "id": 3 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+}


### PR DESCRIPTION
First of three feature PRs from `.context/attachments/pasted_text_2026-04-30_19-28-56.txt`.

## What

Every key in a schema now reports whether it appeared in 100% of the observed parent objects of its enclosing shape. Keys that aren't always present get `\"optional\": true`. Always-present keys stay unannotated so output stays tight.

This is the most important signal for using schermz output as input to a Zod / TypeScript codegen step — it's the difference between `field: T` and `field?: T`.

### Before

```json
{ "country_code": { "types": ["STRING(2)"] } }
```

### After (when the key was missing on some parents)

```json
{ "country_code": { "types": ["STRING(2)"], "optional": true } }
```

## Denominator rules

- **Top-level**: number of objects in the input (or 1 for a single-object input — schermz can't infer optionality from a sample size of 1, nothing is ever marked optional).
- **Nested object key**: number of parents whose enclosing object had this shape.
- **Object inside an array**: total object elements observed across all parent arrays.

## Interaction with `-m`

Without `-m`, distinct object shapes are listed as separate variants. By construction all members of one variant share the same key set, so `optional` never appears within a variant. Use `-m` to flatten variants and surface which keys are sometimes-present in the merged shape.

## Null vs. missing

`{x: null}` is **present** for this signal — different from `{}`. The `null` shows up in `types`, not the flag.

## Snapshot deltas (existing tests)

Two existing snapshots updated, both correctly reflecting input shape variation that was previously invisible:
- `test_schema_from_array_merged`: `country`, `country_code`, `state` on merged `address`; `marital_status` on `personal_data`; `fax` inside the `phones` inner object → all become `optional`.
- `merged_collapses_distinct_object_shapes`: `b` becomes `optional`.

## Tests added (7)

Covers top-level optional, single-object input (none optional), nested-object denominator, unmerged-variant invariant, array-of-objects optional, `null`-counts-as-present, type-variation-is-not-optionality.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 25 passing (was 18)
- [x] README updated with the new annotation explained alongside the `-m` example

## Next

- Feature 2 (enum value extraction) will land in a separate PR once this is in.
- Feature 3 (discriminator detection) consumes feature 2's output and lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)