### PR TITLE
feat: --enum-threshold and "values" annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ A tool to generate a schema for a given JSON file.
 Usage: schermz [OPTIONS] --file <FILE>
 
 Options:
-  -f, --file <FILE>    Path to the JSON file
-  -m, --merge-objects  Whether to merge object types into one
-  -h, --help           Print help
-  -V, --version        Print version
+  -f, --file <FILE>             Path to the JSON file
+  -m, --merge-objects           Whether to merge object types into one
+      --enum-threshold <N>      Emit a "values" enum for scalar fields with
+                                at most N distinct observed values [default: 30]
+  -h, --help                    Print help
+  -V, --version                 Print version
 ```
 
 ## The `-m` argument
@@ -138,6 +140,42 @@ are sometimes-present in the merged shape.
 A key whose value is `null` still counts as "present" for this signal —
 `{ "x": null }` is different from `{}`. The `null` shows up inside `types`,
 not in the optionality flag.
+
+## Enum values
+
+When a scalar field has a small number of distinct observed values, schermz
+emits them as a sorted `"values"` list alongside `"types"`. This lets
+downstream codegen turn `z.string()` into `z.enum(["applied", "in_force"])`,
+which is enforceable, surfaces in error messages, and gives compile-time
+autocomplete.
+
+```json
+{
+  "status": {
+    "types": ["STRING(6, 8)"],
+    "values": ["applied", "in_force", "opened", "revoked"]
+  }
+}
+```
+
+The threshold is configurable with `--enum-threshold N` (default `30`). Pass
+`0` to disable the annotation entirely.
+
+Rules:
+
+- Only scalar fields. A key whose `types` mixes a scalar with an object,
+  array, or boolean variant gets no `"values"`.
+- Single non-null scalar variant only. `STRING + NULL` qualifies (the null is
+  the absence of a value, not a competing scalar). `STRING + NUMBER` does
+  not — too ambiguous to enumerate as one list.
+- Booleans are skipped — trivially enumerable from the type alone, and the
+  noise isn't worth it.
+- Numbers are emitted only if every observed value is an integer. A single
+  float in the set disqualifies it (an open enum of floats isn't useful).
+- Strings longer than 200 characters disqualify the set, even if cardinality
+  is below the threshold (JSON blobs, base64, free-text descriptions).
+
+Strings sort lexicographically. Numbers sort numerically.
 
 ## Output
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,10 @@ struct Args {
     /// Whether to merge object types into one
     #[arg(short, long, action = ArgAction::SetTrue)]
     merge_objects: bool,
+    /// When a scalar field has at most N distinct observed values, emit them
+    /// as an enum-style "values" annotation. Pass 0 to disable.
+    #[arg(long, default_value_t = 30)]
+    enum_threshold: usize,
 }
 
 fn run(args: &Args) -> Result<String, String> {
@@ -28,7 +32,7 @@ fn run(args: &Args) -> Result<String, String> {
             args.file
         ));
     }
-    let schema = schema::Schema::from_json(&json, args.merge_objects);
+    let schema = schema::Schema::from_json(&json, args.merge_objects, args.enum_threshold);
     serde_json::to_string_pretty(&schema.to_json())
         .map_err(|err| format!("failed to serialize schema: {err}"))
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,12 +4,17 @@ mod value_type;
 mod tests;
 
 use itertools::Itertools;
-use serde_json::Value as JsonValue;
+use serde_json::{Number, Value as JsonValue};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use value_type::{SchemaObject, ValueType};
+
+// Drop string values from the enum candidate set if any one is longer than this.
+// Long values (JSON blobs, base64, free-text) won't be useful as enum members
+// downstream even if cardinality is small.
+const MAX_ENUM_STRING_LEN: usize = 200;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SchemaValueType {
@@ -20,19 +25,21 @@ pub enum SchemaValueType {
 }
 
 impl SchemaValueType {
-    fn from_value_type(value_type: &ValueType, merge_objects: bool) -> Self {
+    fn from_value_type(value_type: &ValueType, merge_objects: bool, enum_threshold: usize) -> Self {
         match value_type {
             ValueType::Null => Self::Primitive("NULL".into()),
             ValueType::Bool => Self::Primitive("BOOL".into()),
-            ValueType::Number => Self::Primitive("NUMBER".into()),
-            ValueType::String(len) => Self::String(*len, *len),
-            ValueType::Object(obj) => {
-                Self::Object(Schema::from_objects(vec![obj.clone()], merge_objects))
-            }
+            ValueType::Number(_) => Self::Primitive("NUMBER".into()),
+            ValueType::String { len, .. } => Self::String(*len, *len),
+            ValueType::Object(obj) => Self::Object(Schema::from_objects(
+                vec![obj.clone()],
+                merge_objects,
+                enum_threshold,
+            )),
             ValueType::Array(arr) => {
                 let mut value_types = arr
                     .iter()
-                    .map(|vt| Self::from_value_type(vt, merge_objects))
+                    .map(|vt| Self::from_value_type(vt, merge_objects, enum_threshold))
                     .collect::<Vec<_>>();
                 value_types.dedup();
                 Self::Array(value_types)
@@ -62,10 +69,48 @@ impl SchemaValueType {
     }
 }
 
+/// Bounded set: stops accepting new entries once it has more than `threshold`
+/// distinct values. Used to cap enum-candidate accumulation so we don't waste
+/// memory on high-cardinality fields.
+#[derive(Debug, Clone, PartialEq)]
+struct BoundedSet<T: Eq + Hash> {
+    values: HashSet<T>,
+    capped: bool,
+}
+
+impl<T: Eq + Hash> BoundedSet<T> {
+    fn new() -> Self {
+        Self {
+            values: HashSet::new(),
+            capped: false,
+        }
+    }
+
+    fn insert(&mut self, value: T, threshold: usize) {
+        if self.capped {
+            return;
+        }
+        self.values.insert(value);
+        if self.values.len() > threshold {
+            self.capped = true;
+        }
+    }
+
+    /// Returns the underlying set if the threshold was never exceeded.
+    fn within_threshold(&self) -> Option<&HashSet<T>> {
+        if self.capped {
+            None
+        } else {
+            Some(&self.values)
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct KeyEntry {
     types: Vec<SchemaValueType>,
     seen_count: usize,
+    values: Option<Vec<JsonValue>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -96,10 +141,16 @@ impl Schema {
             .collect()
     }
 
-    fn create_map(objects: Vec<SchemaObject>, merge_objects: bool) -> HashMap<String, KeyEntry> {
+    fn create_map(
+        objects: Vec<SchemaObject>,
+        merge_objects: bool,
+        enum_threshold: usize,
+    ) -> HashMap<String, KeyEntry> {
         let mut types_map = HashMap::<String, Vec<SchemaValueType>>::new();
         let mut seen_counts = HashMap::<String, usize>::new();
         let mut string_lens = HashMap::<String, Vec<usize>>::new();
+        let mut string_values = HashMap::<String, BoundedSet<String>>::new();
+        let mut number_values = HashMap::<String, BoundedSet<Number>>::new();
         let mut object_types = CollectedObjects::new();
         let mut array_object_types = CollectedObjects::new();
         let mut array_primitive_types_map = HashMap::<String, Vec<SchemaValueType>>::new();
@@ -124,7 +175,7 @@ impl Schema {
                                         .or_default()
                                         .push(obj.clone());
                                 }
-                                ValueType::String(len) => {
+                                ValueType::String { len, .. } => {
                                     array_string_lens_map
                                         .entry(key.id.clone())
                                         .or_default()
@@ -137,6 +188,7 @@ impl Schema {
                                     let vtype = SchemaValueType::from_value_type(
                                         primitive_type,
                                         merge_objects,
+                                        enum_threshold,
                                     );
                                     if !entry.contains(&vtype) {
                                         entry.push(vtype);
@@ -145,12 +197,31 @@ impl Schema {
                             }
                         }
                     }
-                    ValueType::String(len) => {
+                    ValueType::String { len, value } => {
                         string_lens.entry(key.id.clone()).or_default().push(*len);
+                        string_values
+                            .entry(key.id.clone())
+                            .or_insert_with(BoundedSet::new)
+                            .insert(value.clone(), enum_threshold);
+                    }
+                    ValueType::Number(num) => {
+                        let entry = types_map.entry(key.id.clone()).or_default();
+                        let vtype = SchemaValueType::Primitive("NUMBER".into());
+                        if !entry.contains(&vtype) {
+                            entry.push(vtype);
+                        }
+                        number_values
+                            .entry(key.id.clone())
+                            .or_insert_with(BoundedSet::new)
+                            .insert(num.clone(), enum_threshold);
                     }
                     primitive_type => {
                         let entry = types_map.entry(key.id.clone()).or_default();
-                        let vtype = SchemaValueType::from_value_type(primitive_type, merge_objects);
+                        let vtype = SchemaValueType::from_value_type(
+                            primitive_type,
+                            merge_objects,
+                            enum_threshold,
+                        );
                         if !entry.contains(&vtype) {
                             entry.push(vtype);
                         }
@@ -173,7 +244,11 @@ impl Schema {
                 types_map
                     .entry(key)
                     .or_default()
-                    .push(SchemaValueType::Object(Schema::from_objects(value, true)));
+                    .push(SchemaValueType::Object(Schema::from_objects(
+                        value,
+                        true,
+                        enum_threshold,
+                    )));
             } else {
                 for objects_group in Self::group_objects_by_keys_fingerprint(value) {
                     types_map
@@ -182,6 +257,7 @@ impl Schema {
                         .push(SchemaValueType::Object(Schema::from_objects(
                             objects_group,
                             false,
+                            enum_threshold,
                         )));
                 }
             }
@@ -199,11 +275,17 @@ impl Schema {
         for key in array_keys {
             let mut all_array_types: Vec<SchemaValueType> = match array_object_types.remove(&key) {
                 Some(value) if merge_objects => {
-                    vec![SchemaValueType::Object(Schema::from_objects(value, true))]
+                    vec![SchemaValueType::Object(Schema::from_objects(
+                        value,
+                        true,
+                        enum_threshold,
+                    ))]
                 }
                 Some(value) => Self::group_objects_by_keys_fingerprint(value)
                     .into_iter()
-                    .map(|group| SchemaValueType::Object(Schema::from_objects(group, false)))
+                    .map(|group| {
+                        SchemaValueType::Object(Schema::from_objects(group, false, enum_threshold))
+                    })
                     .collect(),
                 None => Vec::new(),
             };
@@ -226,16 +308,29 @@ impl Schema {
             .into_iter()
             .map(|(key, types)| {
                 let seen_count = seen_counts.remove(&key).unwrap_or(0);
-                (key, KeyEntry { types, seen_count })
+                let values =
+                    enum_values_for_key(&types, string_values.get(&key), number_values.get(&key));
+                (
+                    key,
+                    KeyEntry {
+                        types,
+                        seen_count,
+                        values,
+                    },
+                )
             })
             .collect()
     }
 
-    fn from_objects(objects: Vec<SchemaObject>, merge_objects: bool) -> Self {
+    fn from_objects(
+        objects: Vec<SchemaObject>,
+        merge_objects: bool,
+        enum_threshold: usize,
+    ) -> Self {
         let parent_count = objects.len();
         Self {
             parent_count,
-            map: Self::create_map(objects, merge_objects),
+            map: Self::create_map(objects, merge_objects, enum_threshold),
         }
     }
 
@@ -249,17 +344,22 @@ impl Schema {
             if entry.seen_count < self.parent_count {
                 out.insert("optional".into(), JsonValue::Bool(true));
             }
+            if let Some(values) = &entry.values {
+                out.insert("values".into(), JsonValue::Array(values.clone()));
+            }
             map.insert(key.clone(), JsonValue::Object(out));
         }
 
         JsonValue::Object(map)
     }
 
-    pub fn from_json(json: &JsonValue, merge_objects: bool) -> Self {
+    pub fn from_json(json: &JsonValue, merge_objects: bool, enum_threshold: usize) -> Self {
         match json {
-            JsonValue::Object(_) => {
-                Self::from_objects(vec![SchemaObject::from_json(json)], merge_objects)
-            }
+            JsonValue::Object(_) => Self::from_objects(
+                vec![SchemaObject::from_json(json)],
+                merge_objects,
+                enum_threshold,
+            ),
             JsonValue::Array(arr) => {
                 let objects = arr
                     .iter()
@@ -269,9 +369,74 @@ impl Schema {
                     })
                     .collect::<Vec<SchemaObject>>();
 
-                Self::from_objects(objects, merge_objects)
+                Self::from_objects(objects, merge_objects, enum_threshold)
             }
             _ => panic!("schermz expects the root JSON value to be an object or an array"),
         }
     }
+}
+
+/// Decide whether a key's distinct scalar values should be emitted as a
+/// `"values"` enum annotation. A single non-null scalar variant (string XOR
+/// number) is required; mixed-type unions are skipped to keep downstream codegen
+/// rules simple.
+fn enum_values_for_key(
+    types: &[SchemaValueType],
+    string_values: Option<&BoundedSet<String>>,
+    number_values: Option<&BoundedSet<Number>>,
+) -> Option<Vec<JsonValue>> {
+    let mut has_string = false;
+    let mut has_number = false;
+    let mut has_other = false;
+    for t in types {
+        match t {
+            SchemaValueType::String(_, _) => has_string = true,
+            SchemaValueType::Primitive(name) if name == "NUMBER" => has_number = true,
+            SchemaValueType::Primitive(name) if name == "NULL" => {}
+            _ => has_other = true,
+        }
+    }
+    if has_other {
+        return None;
+    }
+    match (has_string, has_number) {
+        (true, false) => emit_string_values(string_values?),
+        (false, true) => emit_number_values(number_values?),
+        _ => None,
+    }
+}
+
+fn emit_string_values(set: &BoundedSet<String>) -> Option<Vec<JsonValue>> {
+    let values = set.within_threshold()?;
+    if values.iter().any(|s| s.len() > MAX_ENUM_STRING_LEN) {
+        return None;
+    }
+    let mut sorted: Vec<&String> = values.iter().collect();
+    sorted.sort();
+    Some(
+        sorted
+            .into_iter()
+            .map(|s| JsonValue::String(s.clone()))
+            .collect(),
+    )
+}
+
+fn emit_number_values(set: &BoundedSet<Number>) -> Option<Vec<JsonValue>> {
+    let values = set.within_threshold()?;
+    if !values.iter().all(|n| n.is_i64() || n.is_u64()) {
+        // Floats aren't useful as enum members.
+        return None;
+    }
+    let mut sorted: Vec<&Number> = values.iter().collect();
+    sorted.sort_by_key(|n| {
+        n.as_i64()
+            .or_else(|| n.as_u64().map(|u| u as i64))
+            .unwrap_or(0)
+    });
+    Some(
+        sorted
+            .into_iter()
+            .map(|n| JsonValue::Number(n.clone()))
+            .collect(),
+    )
 }

--- a/src/schema/snapshots/schermz__schema__tests__array_of_objects_optional_field.snap
+++ b/src/schema/snapshots/schermz__schema__tests__array_of_objects_optional_field.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 368
-expression: "Schema::from_json(&json, true).to_json()"
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "items": {
@@ -12,12 +12,19 @@ expression: "Schema::from_json(&json, true).to_json()"
             "a": {
               "types": [
                 "NUMBER"
+              ],
+              "values": [
+                1,
+                2
               ]
             },
             "b": {
               "optional": true,
               "types": [
                 "NUMBER"
+              ],
+              "values": [
+                20
               ]
             }
           }

--- a/src/schema/snapshots/schermz__schema__tests__bool_only_field_skips_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__bool_only_field_skips_values.snap
@@ -1,0 +1,12 @@
+---
+source: src/schema/tests.rs
+assertion_line: 488
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "active": {
+    "types": [
+      "BOOL"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__custom_threshold_admits_more_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__custom_threshold_admits_more_values.snap
@@ -1,0 +1,45 @@
+---
+source: src/schema/tests.rs
+assertion_line: 425
+expression: "Schema::from_json(&json, false, 100).to_json()"
+---
+{
+  "k": {
+    "types": [
+      "STRING(2, 3)"
+    ],
+    "values": [
+      "v0",
+      "v1",
+      "v10",
+      "v11",
+      "v12",
+      "v13",
+      "v14",
+      "v15",
+      "v16",
+      "v17",
+      "v18",
+      "v19",
+      "v2",
+      "v20",
+      "v21",
+      "v22",
+      "v23",
+      "v24",
+      "v25",
+      "v26",
+      "v27",
+      "v28",
+      "v29",
+      "v3",
+      "v30",
+      "v4",
+      "v5",
+      "v6",
+      "v7",
+      "v8",
+      "v9"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__deeply_nested_objects.snap
+++ b/src/schema/snapshots/schermz__schema__tests__deeply_nested_objects.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 66
-expression: "Schema::from_json(&json, false).to_json()"
+expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
   "a": {
@@ -19,6 +19,9 @@ expression: "Schema::from_json(&json, false).to_json()"
                           "value": {
                             "types": [
                               "STRING(4)"
+                            ],
+                            "values": [
+                              "deep"
                             ]
                           }
                         }

--- a/src/schema/snapshots/schermz__schema__tests__float_numbers_skip_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__float_numbers_skip_values.snap
@@ -1,0 +1,12 @@
+---
+source: src/schema/tests.rs
+assertion_line: 476
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "price": {
+    "types": [
+      "NUMBER"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__integer_only_numbers_emit_values_sorted_numerically.snap
+++ b/src/schema/snapshots/schermz__schema__tests__integer_only_numbers_emit_values_sorted_numerically.snap
@@ -1,26 +1,19 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 325
+assertion_line: 465
 expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
-  "a": {
+  "code": {
     "types": [
       "NUMBER"
     ],
     "values": [
       1,
       2,
-      3
-    ]
-  },
-  "b": {
-    "optional": true,
-    "types": [
-      "NUMBER"
-    ],
-    "values": [
-      20
+      3,
+      5,
+      8
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__long_strings_skip_values_even_below_threshold.snap
+++ b/src/schema/snapshots/schermz__schema__tests__long_strings_skip_values_even_below_threshold.snap
@@ -1,0 +1,12 @@
+---
+source: src/schema/tests.rs
+assertion_line: 453
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "blob": {
+    "types": [
+      "STRING(5, 250)"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__merged_collapses_distinct_object_shapes.snap
+++ b/src/schema/snapshots/schermz__schema__tests__merged_collapses_distinct_object_shapes.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 113
-expression: "Schema::from_json(&json, true).to_json()"
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "info": {
@@ -10,12 +10,18 @@ expression: "Schema::from_json(&json, true).to_json()"
         "a": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         },
         "b": {
           "optional": true,
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            2
           ]
         }
       }

--- a/src/schema/snapshots/schermz__schema__tests__merged_strings_collapse_min_max.snap
+++ b/src/schema/snapshots/schermz__schema__tests__merged_strings_collapse_min_max.snap
@@ -1,12 +1,17 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 95
-expression: "Schema::from_json(&json, true).to_json()"
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "name": {
     "types": [
       "STRING(2, 4)"
+    ],
+    "values": [
+      "ab",
+      "abc",
+      "abcd"
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__mixed_string_and_number_skips_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__mixed_string_and_number_skips_values.snap
@@ -1,0 +1,13 @@
+---
+source: src/schema/tests.rs
+assertion_line: 442
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "id": {
+    "types": [
+      "NUMBER",
+      "STRING(1)"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__nested_object_optional_uses_correct_denominator.snap
+++ b/src/schema/snapshots/schermz__schema__tests__nested_object_optional_uses_correct_denominator.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 344
-expression: "Schema::from_json(&json, true).to_json()"
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "addr": {
@@ -11,12 +11,18 @@ expression: "Schema::from_json(&json, true).to_json()"
         "x": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         },
         "y": {
           "optional": true,
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            2
           ]
         }
       }
@@ -26,6 +32,9 @@ expression: "Schema::from_json(&json, true).to_json()"
     "optional": true,
     "types": [
       "NUMBER"
+    ],
+    "values": [
+      1
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__null_value_counts_as_present.snap
+++ b/src/schema/snapshots/schermz__schema__tests__null_value_counts_as_present.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 380
-expression: "Schema::from_json(&json, false).to_json()"
+expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
   "x": {
@@ -9,12 +9,18 @@ expression: "Schema::from_json(&json, false).to_json()"
     "types": [
       "NUMBER",
       "NULL"
+    ],
+    "values": [
+      1
     ]
   },
   "y": {
     "optional": true,
     "types": [
       "NUMBER"
+    ],
+    "values": [
+      7
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__schema_from_array_merged.snap
+++ b/src/schema/snapshots/schermz__schema__tests__schema_from_array_merged.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 223
-expression: "Schema::from_json(&json, true).to_json()"
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "address": {
@@ -11,34 +11,61 @@ expression: "Schema::from_json(&json, true).to_json()"
         "city": {
           "types": [
             "STRING(6, 8)"
+          ],
+          "values": [
+            "Caldwell",
+            "London",
+            "Potsdam"
           ]
         },
         "country": {
           "optional": true,
           "types": [
             "STRING(3, 7)"
+          ],
+          "values": [
+            "Germany",
+            "USA"
           ]
         },
         "country_code": {
           "optional": true,
           "types": [
             "STRING(2)"
+          ],
+          "values": [
+            "UK",
+            "US"
           ]
         },
         "state": {
           "optional": true,
           "types": [
             "STRING(10, 11)"
+          ],
+          "values": [
+            "Brandenburg",
+            "New Jersey"
           ]
         },
         "street": {
           "types": [
             "STRING(9, 17)"
+          ],
+          "values": [
+            "10 Downing Street",
+            "14 Aspen Drive",
+            "Gr. Weg 3"
           ]
         },
         "zip": {
           "types": [
             "STRING(5, 8)"
+          ],
+          "values": [
+            "12345",
+            "14467",
+            "NJ 07006"
           ]
         }
       }
@@ -53,6 +80,12 @@ expression: "Schema::from_json(&json, true).to_json()"
   "name": {
     "types": [
       "STRING(8, 15)"
+    ],
+    "values": [
+      "Angela Merkel",
+      "Jane Doe",
+      "Sherlock Holmes",
+      "Tony Soprano"
     ]
   },
   "personal_data": {
@@ -61,12 +94,20 @@ expression: "Schema::from_json(&json, true).to_json()"
         "gender": {
           "types": [
             "STRING(4, 6)"
+          ],
+          "values": [
+            "female",
+            "male"
           ]
         },
         "marital_status": {
           "optional": true,
           "types": [
             "STRING(6, 7)"
+          ],
+          "values": [
+            "married",
+            "single"
           ]
         }
       }
@@ -82,11 +123,19 @@ expression: "Schema::from_json(&json, true).to_json()"
               "optional": true,
               "types": [
                 "STRING(13)"
+              ],
+              "values": [
+                "+49 343156780"
               ]
             },
             "mobile": {
               "types": [
                 "STRING(10, 13)"
+              ],
+              "values": [
+                "+1 3456789",
+                "+44 3456789",
+                "+49 343156789"
               ]
             }
           },
@@ -99,6 +148,10 @@ expression: "Schema::from_json(&json, true).to_json()"
   "title": {
     "types": [
       "STRING(0, 3)"
+    ],
+    "values": [
+      "",
+      "Dr."
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__schema_from_array_unmerged.snap
+++ b/src/schema/snapshots/schermz__schema__tests__schema_from_array_unmerged.snap
@@ -1,6 +1,7 @@
 ---
-source: src/schema.rs
-expression: "Schema::from_json(&json, false).to_json()"
+source: src/schema/tests.rs
+assertion_line: 312
+expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
   "address": {
@@ -10,21 +11,33 @@ expression: "Schema::from_json(&json, false).to_json()"
         "city": {
           "types": [
             "STRING(6)"
+          ],
+          "values": [
+            "London"
           ]
         },
         "country_code": {
           "types": [
             "STRING(2)"
+          ],
+          "values": [
+            "UK"
           ]
         },
         "street": {
           "types": [
             "STRING(17)"
+          ],
+          "values": [
+            "10 Downing Street"
           ]
         },
         "zip": {
           "types": [
             "STRING(5)"
+          ],
+          "values": [
+            "12345"
           ]
         }
       },
@@ -32,31 +45,49 @@ expression: "Schema::from_json(&json, false).to_json()"
         "city": {
           "types": [
             "STRING(8)"
+          ],
+          "values": [
+            "Caldwell"
           ]
         },
         "country": {
           "types": [
             "STRING(3)"
+          ],
+          "values": [
+            "USA"
           ]
         },
         "country_code": {
           "types": [
             "STRING(2)"
+          ],
+          "values": [
+            "US"
           ]
         },
         "state": {
           "types": [
             "STRING(10)"
+          ],
+          "values": [
+            "New Jersey"
           ]
         },
         "street": {
           "types": [
             "STRING(14)"
+          ],
+          "values": [
+            "14 Aspen Drive"
           ]
         },
         "zip": {
           "types": [
             "STRING(8)"
+          ],
+          "values": [
+            "NJ 07006"
           ]
         }
       },
@@ -64,26 +95,41 @@ expression: "Schema::from_json(&json, false).to_json()"
         "city": {
           "types": [
             "STRING(7)"
+          ],
+          "values": [
+            "Potsdam"
           ]
         },
         "country": {
           "types": [
             "STRING(7)"
+          ],
+          "values": [
+            "Germany"
           ]
         },
         "state": {
           "types": [
             "STRING(11)"
+          ],
+          "values": [
+            "Brandenburg"
           ]
         },
         "street": {
           "types": [
             "STRING(9)"
+          ],
+          "values": [
+            "Gr. Weg 3"
           ]
         },
         "zip": {
           "types": [
             "STRING(5)"
+          ],
+          "values": [
+            "14467"
           ]
         }
       }
@@ -98,6 +144,12 @@ expression: "Schema::from_json(&json, false).to_json()"
   "name": {
     "types": [
       "STRING(8, 15)"
+    ],
+    "values": [
+      "Angela Merkel",
+      "Jane Doe",
+      "Sherlock Holmes",
+      "Tony Soprano"
     ]
   },
   "personal_data": {
@@ -106,11 +158,19 @@ expression: "Schema::from_json(&json, false).to_json()"
         "gender": {
           "types": [
             "STRING(4, 6)"
+          ],
+          "values": [
+            "female",
+            "male"
           ]
         },
         "marital_status": {
           "types": [
             "STRING(6, 7)"
+          ],
+          "values": [
+            "married",
+            "single"
           ]
         }
       },
@@ -118,6 +178,9 @@ expression: "Schema::from_json(&json, false).to_json()"
         "gender": {
           "types": [
             "STRING(6)"
+          ],
+          "values": [
+            "female"
           ]
         }
       }
@@ -132,6 +195,10 @@ expression: "Schema::from_json(&json, false).to_json()"
             "mobile": {
               "types": [
                 "STRING(10, 11)"
+              ],
+              "values": [
+                "+1 3456789",
+                "+44 3456789"
               ]
             }
           },
@@ -139,11 +206,17 @@ expression: "Schema::from_json(&json, false).to_json()"
             "fax": {
               "types": [
                 "STRING(13)"
+              ],
+              "values": [
+                "+49 343156780"
               ]
             },
             "mobile": {
               "types": [
                 "STRING(13)"
+              ],
+              "values": [
+                "+49 343156789"
               ]
             }
           },
@@ -156,6 +229,10 @@ expression: "Schema::from_json(&json, false).to_json()"
   "title": {
     "types": [
       "STRING(0, 3)"
+    ],
+    "values": [
+      "",
+      "Dr."
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__schema_from_object.snap
+++ b/src/schema/snapshots/schermz__schema__tests__schema_from_object.snap
@@ -1,6 +1,7 @@
 ---
-source: src/schema.rs
-expression: "Schema::from_json(&json).to_json()"
+source: src/schema/tests.rs
+assertion_line: 134
+expression: "Schema::from_json(&json, true, 30).to_json()"
 ---
 {
   "address": {
@@ -9,11 +10,17 @@ expression: "Schema::from_json(&json).to_json()"
         "city": {
           "types": [
             "STRING(6)"
+          ],
+          "values": [
+            "London"
           ]
         },
         "street": {
           "types": [
             "STRING(17)"
+          ],
+          "values": [
+            "10 Downing Street"
           ]
         }
       }
@@ -22,11 +29,17 @@ expression: "Schema::from_json(&json).to_json()"
   "age": {
     "types": [
       "NUMBER"
+    ],
+    "values": [
+      43
     ]
   },
   "name": {
     "types": [
       "STRING(8)"
+    ],
+    "values": [
+      "John Doe"
     ]
   },
   "phones": {
@@ -37,6 +50,9 @@ expression: "Schema::from_json(&json).to_json()"
             "mobile": {
               "types": [
                 "STRING(11)"
+              ],
+              "values": [
+                "+44 3456789"
               ]
             }
           },
@@ -49,6 +65,9 @@ expression: "Schema::from_json(&json).to_json()"
   "title": {
     "types": [
       "STRING(0)"
+    ],
+    "values": [
+      ""
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__string_enum_over_threshold_skipped.snap
+++ b/src/schema/snapshots/schermz__schema__tests__string_enum_over_threshold_skipped.snap
@@ -1,0 +1,12 @@
+---
+source: src/schema/tests.rs
+assertion_line: 414
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "k": {
+    "types": [
+      "STRING(2, 3)"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__string_enum_two_distinct_values_emitted_sorted.snap
+++ b/src/schema/snapshots/schermz__schema__tests__string_enum_two_distinct_values_emitted_sorted.snap
@@ -1,23 +1,16 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 332
+assertion_line: 403
 expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
-  "a": {
+  "status": {
     "types": [
-      "NUMBER"
+      "STRING(6, 8)"
     ],
     "values": [
-      1
-    ]
-  },
-  "b": {
-    "types": [
-      "NUMBER"
-    ],
-    "values": [
-      2
+      "in_force",
+      "opened"
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__string_with_null_still_emits_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__string_with_null_still_emits_values.snap
@@ -1,23 +1,17 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 332
+assertion_line: 500
 expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
-  "a": {
+  "tag": {
     "types": [
-      "NUMBER"
+      "NULL",
+      "STRING(1)"
     ],
     "values": [
-      1
-    ]
-  },
-  "b": {
-    "types": [
-      "NUMBER"
-    ],
-    "values": [
-      2
+      "a",
+      "b"
     ]
   }
 }

--- a/src/schema/snapshots/schermz__schema__tests__string_with_object_skips_values.snap
+++ b/src/schema/snapshots/schermz__schema__tests__string_with_object_skips_values.snap
@@ -1,0 +1,22 @@
+---
+source: src/schema/tests.rs
+assertion_line: 510
+expression: "Schema::from_json(&json, false, 30).to_json()"
+---
+{
+  "thing": {
+    "types": [
+      "STRING(5)",
+      {
+        "nested": {
+          "types": [
+            "NUMBER"
+          ],
+          "values": [
+            1
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__threshold_zero_disables_values_entirely.snap
+++ b/src/schema/snapshots/schermz__schema__tests__threshold_zero_disables_values_entirely.snap
@@ -1,0 +1,12 @@
+---
+source: src/schema/tests.rs
+assertion_line: 431
+expression: "Schema::from_json(&json, false, 0).to_json()"
+---
+{
+  "k": {
+    "types": [
+      "STRING(1)"
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__unmerged_keeps_distinct_object_shapes.snap
+++ b/src/schema/snapshots/schermz__schema__tests__unmerged_keeps_distinct_object_shapes.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 104
-expression: "Schema::from_json(&json, false).to_json()"
+expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
   "info": {
@@ -10,6 +10,9 @@ expression: "Schema::from_json(&json, false).to_json()"
         "a": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         }
       },
@@ -17,11 +20,17 @@ expression: "Schema::from_json(&json, false).to_json()"
         "a": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         },
         "b": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            2
           ]
         }
       }

--- a/src/schema/snapshots/schermz__schema__tests__unmerged_variants_have_no_optional_within.snap
+++ b/src/schema/snapshots/schermz__schema__tests__unmerged_variants_have_no_optional_within.snap
@@ -1,7 +1,7 @@
 ---
 source: src/schema/tests.rs
 assertion_line: 355
-expression: "Schema::from_json(&json, false).to_json()"
+expression: "Schema::from_json(&json, false, 30).to_json()"
 ---
 {
   "addr": {
@@ -10,11 +10,17 @@ expression: "Schema::from_json(&json, false).to_json()"
         "x": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         },
         "y": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            2
           ]
         }
       },
@@ -22,6 +28,9 @@ expression: "Schema::from_json(&json, false).to_json()"
         "x": {
           "types": [
             "NUMBER"
+          ],
+          "values": [
+            1
           ]
         }
       }

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -3,50 +3,50 @@ use super::*;
 #[test]
 #[should_panic]
 fn root_null_panics() {
-    Schema::from_json(&serde_json::Value::Null, false);
+    Schema::from_json(&serde_json::Value::Null, false, 30);
 }
 
 #[test]
 #[should_panic]
 fn root_string_panics() {
-    Schema::from_json(&serde_json::json!("hello"), false);
+    Schema::from_json(&serde_json::json!("hello"), false, 30);
 }
 
 #[test]
 #[should_panic]
 fn root_number_panics() {
-    Schema::from_json(&serde_json::json!(42), false);
+    Schema::from_json(&serde_json::json!(42), false, 30);
 }
 
 #[test]
 #[should_panic]
 fn root_bool_panics() {
-    Schema::from_json(&serde_json::json!(true), false);
+    Schema::from_json(&serde_json::json!(true), false, 30);
 }
 
 #[test]
 fn empty_root_object() {
     let json = serde_json::json!({});
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
 fn empty_root_array() {
     let json = serde_json::json!([]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
 fn root_array_with_only_primitives_is_empty() {
     // The CLI ignores non-object elements at the root array level.
     let json = serde_json::json!([1, "hello", null, true]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
 fn bool_values() {
     let json = serde_json::json!({ "active": true, "verified": false });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn empty_nested_object_and_array() {
         "empty_obj": {},
         "empty_arr": []
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn deeply_nested_objects() {
     let json = serde_json::json!({
         "a": { "b": { "c": { "d": { "value": "deep" } } } }
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn array_of_primitives_only() {
     let json = serde_json::json!({
         "tags": [1, 2, "three", "four", null, true]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn nested_arrays_with_strings() {
     let json = serde_json::json!({
         "matrix": [["a", "bb"], ["ccc"]]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn merged_strings_collapse_min_max() {
         { "name": "abcd" },
         { "name": "abc" }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn unmerged_keeps_distinct_object_shapes() {
         { "info": { "a": 1 } },
         { "info": { "a": 1, "b": 2 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn merged_collapses_distinct_object_shapes() {
         { "info": { "a": 1 } },
         { "info": { "a": 1, "b": 2 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_schema_from_object() {
         ]
     });
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -220,7 +220,7 @@ fn test_schema_from_array_merged() {
         }
     ]);
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -309,7 +309,7 @@ fn test_schema_from_array_unmerged() {
         }
     ]);
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 // ---------- Feature 1: optionality tracking ----------
@@ -322,14 +322,14 @@ fn optional_top_level_key_in_array() {
         { "a": 2, "b": 20 },
         { "a": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
 fn single_object_input_never_marks_optional() {
     // Sample size of 1 -> we can't infer optionality.
     let json = serde_json::json!({ "a": 1, "b": 2 });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn nested_object_optional_uses_correct_denominator() {
         { "addr": { "x": 1 } },
         { "other": 1 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn unmerged_variants_have_no_optional_within() {
         { "addr": { "x": 1, "y": 2 } },
         { "addr": { "x": 1 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -365,7 +365,7 @@ fn array_of_objects_optional_field() {
             { "a": 2, "b": 20 }
         ]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, true).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
 }
 
 #[test]
@@ -377,7 +377,7 @@ fn null_value_counts_as_present() {
         { "x": null },
         { "y": 7 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }
 
 #[test]
@@ -388,5 +388,124 @@ fn type_variation_alone_is_not_optionality() {
         { "id": "two" },
         { "id": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+// ---------- Feature 2: enum value extraction ----------
+
+#[test]
+fn string_enum_two_distinct_values_emitted_sorted() {
+    let json = serde_json::json!([
+        { "status": "in_force" },
+        { "status": "opened" },
+        { "status": "in_force" }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn string_enum_over_threshold_skipped() {
+    // 31 distinct values, default threshold is 30 -> no `values` emitted.
+    let mut items = Vec::new();
+    for i in 0..31 {
+        items.push(serde_json::json!({ "k": format!("v{i}") }));
+    }
+    let json = serde_json::Value::Array(items);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn custom_threshold_admits_more_values() {
+    // Same 31 distinct values, threshold raised to 100 -> `values` is emitted.
+    let mut items = Vec::new();
+    for i in 0..31 {
+        items.push(serde_json::json!({ "k": format!("v{i}") }));
+    }
+    let json = serde_json::Value::Array(items);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 100).to_json());
+}
+
+#[test]
+fn threshold_zero_disables_values_entirely() {
+    let json = serde_json::json!([{ "k": "a" }, { "k": "b" }]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 0).to_json());
+}
+
+#[test]
+fn mixed_string_and_number_skips_values() {
+    // Single key sometimes a string, sometimes a number -> no `values`.
+    let json = serde_json::json!([
+        { "id": "a" },
+        { "id": 1 },
+        { "id": "b" }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn long_strings_skip_values_even_below_threshold() {
+    // Two distinct values, but one is over MAX_ENUM_STRING_LEN (200 chars).
+    let big = "x".repeat(250);
+    let json = serde_json::json!([
+        { "blob": "small" },
+        { "blob": big }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn integer_only_numbers_emit_values_sorted_numerically() {
+    let json = serde_json::json!([
+        { "code": 8 },
+        { "code": 1 },
+        { "code": 5 },
+        { "code": 2 },
+        { "code": 3 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn float_numbers_skip_values() {
+    // Any float disqualifies the whole set -- not useful as enum members.
+    let json = serde_json::json!([
+        { "price": 1 },
+        { "price": 2.5 },
+        { "price": 3 }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn bool_only_field_skips_values() {
+    // Booleans are trivially enumerable from the type alone; spec recommends
+    // skipping them to avoid noise.
+    let json = serde_json::json!([
+        { "active": true },
+        { "active": false },
+        { "active": true }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn string_with_null_still_emits_values() {
+    // STRING + NULL is not "mixed" for the purpose of values -- null is the
+    // absence of a value, not a competing scalar type.
+    let json = serde_json::json!([
+        { "tag": "a" },
+        { "tag": null },
+        { "tag": "b" }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+}
+
+#[test]
+fn string_with_object_skips_values() {
+    // Mixing a scalar with a non-scalar variant disqualifies the key.
+    let json = serde_json::json!([
+        { "thing": "hello" },
+        { "thing": { "nested": 1 } }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
 }

--- a/src/schema/value_type.rs
+++ b/src/schema/value_type.rs
@@ -1,11 +1,11 @@
-use serde_json::Value as JsonValue;
+use serde_json::{Number, Value as JsonValue};
 
 #[derive(Debug, Clone)]
 pub(super) enum ValueType {
     Null,
     Bool,
-    Number,
-    String(usize),
+    Number(Number),
+    String { len: usize, value: String },
     Object(SchemaObject),
     Array(Vec<ValueType>),
 }
@@ -26,8 +26,11 @@ impl ValueType {
         match json {
             JsonValue::Null => Self::Null,
             JsonValue::Bool(_) => Self::Bool,
-            JsonValue::Number(_) => Self::Number,
-            JsonValue::String(s) => Self::String(s.len()),
+            JsonValue::Number(n) => Self::Number(n.clone()),
+            JsonValue::String(s) => Self::String {
+                len: s.len(),
+                value: s.clone(),
+            },
             JsonValue::Object(_) => Self::Object(SchemaObject::from_json(json)),
             JsonValue::Array(arr) => {
                 let values = arr.iter().map(Self::from_json).collect();


### PR DESCRIPTION
Second of three feature PRs. **Stacked on #136 (optionality)** — base will become single-feature once #136 merges.

## What

When a scalar field has at most `--enum-threshold` (default `30`) distinct observed values, schermz now emits them as a sorted `"values"` list alongside `"types"`.

```json
{
  "status": {
    "types": ["STRING(6, 8)"],
    "values": ["applied", "in_force", "opened", "revoked"]
  }
}
```

Pass `--enum-threshold 0` to disable.

## Rules

- **Only scalar fields.** Mixing a scalar with object/array variants disqualifies the key.
- **Single non-null scalar variant.** `STRING + NULL` qualifies (null is the absence of a value); `STRING + NUMBER` does not — too ambiguous to emit as one list.
- **Booleans skipped.** Trivially enumerable from the type alone; not worth the noise.
- **Numbers only if all integers.** A single float in the set disqualifies it. Open enums of floats aren't useful.
- **Long strings skipped.** Any single value > 200 characters disqualifies the set, even under threshold (JSON blobs, base64, free-text).
- **Stable order.** Strings sort lexicographically, numbers numerically.

## Implementation notes

- `ValueType` internally now carries the raw scalar value (`Number`, `String { len, value }`). The `len` stays so `STRING(min, max)` keeps working.
- A `BoundedSet<T>` caps accumulation at `threshold + 1` distinct values per key per scalar type, so memory stays bounded on high-cardinality fields.
- The emit decision happens once per key at the end of `create_map`, looking at `types` to classify (string-only vs number-only vs mixed).

## Snapshot deltas

Existing snapshots pick up `"values"` on small-cardinality scalar fields. Notable: `age` in `test_schema_from_array_merged` (which is `STRING + NUMBER`) correctly **does not** get values — the mixed-type rule fires.

## Tests added (11)

- 2 distinct strings → emitted, sorted
- 31 distinct strings, default threshold → skipped
- Same with `--enum-threshold 100` → emitted (sanity-check threshold flow)
- `--enum-threshold 0` → never emit
- `STRING + NUMBER` → skipped
- 250-char string → skipped (long-value guard)
- 5 distinct integers → emitted, sorted numerically
- Float in number set → skipped
- All-bool field → skipped
- `STRING + NULL` → still emits
- `STRING + Object` → skipped (mixed scalar + non-scalar)

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 36 passing (was 25)
- [x] CLI smoke test on a small enum-y fixture, verified output

## Stack

Sits on top of #136. Once #136 merges, the diff against main will narrow to just feature 2.

## Next

Feature 3 (discriminator detection) consumes this PR's `values` data and is the last of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)