### PR TITLE
feat: discriminator detection for object-shape unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@ A tool to generate a schema for a given JSON file.
 Usage: schermz [OPTIONS] --file <FILE>
 
 Options:
-  -f, --file <FILE>             Path to the JSON file
-  -m, --merge-objects           Whether to merge object types into one
-      --enum-threshold <N>      Emit a "values" enum for scalar fields with
-                                at most N distinct observed values [default: 30]
-  -h, --help                    Print help
-  -V, --version                 Print version
+  -f, --file <FILE>                       Path to the JSON file
+  -m, --merge-objects                     Whether to merge object types into one
+      --enum-threshold <N>                Emit a "values" enum for scalar fields
+                                          with at most N distinct observed values
+                                          [default: 30]
+      --discriminator-max-arms <N>        Skip the discriminator annotation when
+                                          the union has more than N total values
+                                          [default: 20]
+      --discriminator-fields <FIELDS>     Comma-separated priority list of fields
+                                          to consider as discriminator (overrides
+                                          auto-detection)
+  -h, --help                              Print help
+  -V, --version                           Print version
 ```
 
 ## The `-m` argument
@@ -176,6 +183,83 @@ Rules:
   is below the threshold (JSON blobs, base64, free-text descriptions).
 
 Strings sort lexicographically. Numbers sort numerically.
+
+## Discriminator detection
+
+When a key's `types` (or an array's element list) contains 2+ distinct object
+shapes, schermz looks for a single field whose values uniquely identify each
+variant. If found, it annotates both the union and the field:
+
+```json
+{
+  "additionalPayments": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "status": { "types": ["STRING(6)"], "values": ["opened"], "discriminator": true },
+            "amount": { "types": ["NUMBER"] }
+          },
+          {
+            "status": { "types": ["STRING(8)"], "values": ["in_force"], "discriminator": true },
+            "amount": { "types": ["NUMBER"] },
+            "paidDate": { "types": ["STRING(10)"] }
+          }
+        ],
+        "discriminator": "status"
+      }
+    ]
+  }
+}
+```
+
+This is what downstream codegen needs to emit `z.discriminatedUnion("status", [...])`
+instead of a plain `z.union([...])`. Discriminated unions validate faster and
+produce far better error messages.
+
+### How a field qualifies
+
+A field is a discriminator candidate when:
+
+- It exists in **every** variant.
+- It's a scalar with a `"values"` enum set in every variant (so feature-2's
+  enum extraction has to have succeeded).
+- Its values are **pairwise disjoint** across the variants — no value appears
+  in more than one variant's set.
+- It's not optional in any variant.
+- The total number of distinct values across all variants is at most
+  `--discriminator-max-arms` (default `20`). Above that, a discriminated union
+  isn't useful — it's effectively unbounded.
+
+If multiple fields qualify, schermz picks the one with the smallest total
+cardinality (fewest distinct values across variants), tie-breaking by name
+lexicographically. Detection is **always-on** when not using `-m`. With `-m`,
+distinct shapes are collapsed before this analysis runs, so nothing happens.
+
+### Forcing a discriminator
+
+If the heuristic doesn't pick the field you want — or doesn't pick anything —
+use `--discriminator-fields` with a comma-separated priority list:
+
+```bash
+schermz --discriminator-fields=status,kind -f data.json
+```
+
+When set, only the listed fields are considered, in the listed order. The
+first one that qualifies wins. If none qualify, no discriminator is emitted
+(no auto fallback). This is the escape hatch for cases where the heuristic
+picks a coincidentally-disjoint field, or for forcing a specific
+discriminator when several qualify.
+
+### Known limitations
+
+- **Coincidental disjointness can produce false positives.** If the input
+  happens to have unique values per variant for some unrelated field, that
+  field will be picked. Use `--discriminator-fields` to override.
+- **Composite discriminators are not detected.** If your real discriminator
+  is `(status, invested)` together but neither alone is sufficient, schermz
+  will return no discriminator. Hand-pick one of them with
+  `--discriminator-fields` if it gets you close enough.
 
 ## Output
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,16 @@ struct Args {
     /// as an enum-style "values" annotation. Pass 0 to disable.
     #[arg(long, default_value_t = 30)]
     enum_threshold: usize,
+    /// Maximum total cardinality across all variants for a field to qualify
+    /// as a discriminator. Above this, the discriminator annotation is skipped.
+    #[arg(long, default_value_t = 20)]
+    discriminator_max_arms: usize,
+    /// Comma-separated priority list of field names to consider when picking
+    /// a discriminator. When set, the auto-detection is restricted to these
+    /// fields (in the listed order). Useful for forcing a known-good
+    /// discriminator when the heuristic doesn't pick one.
+    #[arg(long, value_delimiter = ',')]
+    discriminator_fields: Vec<String>,
 }
 
 fn run(args: &Args) -> Result<String, String> {
@@ -32,7 +42,13 @@ fn run(args: &Args) -> Result<String, String> {
             args.file
         ));
     }
-    let schema = schema::Schema::from_json(&json, args.merge_objects, args.enum_threshold);
+    let config = schema::Config {
+        merge_objects: args.merge_objects,
+        enum_threshold: args.enum_threshold,
+        discriminator_max_arms: args.discriminator_max_arms,
+        discriminator_fields: args.discriminator_fields.clone(),
+    };
+    let schema = schema::Schema::from_json(&json, &config);
     serde_json::to_string_pretty(&schema.to_json())
         .map_err(|err| format!("failed to serialize schema: {err}"))
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -16,38 +16,66 @@ use value_type::{SchemaObject, ValueType};
 // downstream even if cardinality is small.
 const MAX_ENUM_STRING_LEN: usize = 200;
 
+/// Knobs for schema construction. Defaults match the CLI defaults.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub merge_objects: bool,
+    pub enum_threshold: usize,
+    pub discriminator_max_arms: usize,
+    /// When non-empty, only these field names are considered as candidate
+    /// discriminators (in the listed order). When empty, the algorithm
+    /// auto-picks among all qualifying candidates.
+    pub discriminator_fields: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            merge_objects: false,
+            enum_threshold: 30,
+            discriminator_max_arms: 20,
+            discriminator_fields: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SchemaValueType {
     Primitive(String),
     String(usize, usize),
-    Array(Vec<SchemaValueType>),
+    Array {
+        types: Vec<SchemaValueType>,
+        discriminator: Option<String>,
+    },
     Object(Schema),
 }
 
 impl SchemaValueType {
-    fn from_value_type(value_type: &ValueType, merge_objects: bool, enum_threshold: usize) -> Self {
+    fn from_value_type(value_type: &ValueType, config: &Config) -> Self {
         match value_type {
             ValueType::Null => Self::Primitive("NULL".into()),
             ValueType::Bool => Self::Primitive("BOOL".into()),
             ValueType::Number(_) => Self::Primitive("NUMBER".into()),
             ValueType::String { len, .. } => Self::String(*len, *len),
-            ValueType::Object(obj) => Self::Object(Schema::from_objects(
-                vec![obj.clone()],
-                merge_objects,
-                enum_threshold,
-            )),
+            ValueType::Object(obj) => Self::Object(Schema::from_objects(vec![obj.clone()], config)),
             ValueType::Array(arr) => {
-                let mut value_types = arr
+                let mut types = arr
                     .iter()
-                    .map(|vt| Self::from_value_type(vt, merge_objects, enum_threshold))
+                    .map(|vt| Self::from_value_type(vt, config))
                     .collect::<Vec<_>>();
-                value_types.dedup();
-                Self::Array(value_types)
+                types.dedup();
+                Self::Array {
+                    types,
+                    discriminator: None,
+                }
             }
         }
     }
 
-    pub fn to_json(&self) -> JsonValue {
+    /// `inherited_discriminator` carries down the discriminator field name
+    /// from an enclosing union (so the matching key in nested variant Schemas
+    /// can be marked with `"discriminator": true`).
+    fn to_json(&self, inherited_discriminator: Option<&str>) -> JsonValue {
         match self {
             SchemaValueType::Primitive(name) => JsonValue::String(name.clone()),
             SchemaValueType::String(min, max) => {
@@ -57,14 +85,22 @@ impl SchemaValueType {
                     JsonValue::String(format!("STRING({min}, {max})"))
                 }
             }
-            SchemaValueType::Array(v_types) => {
-                let types = v_types
+            SchemaValueType::Array {
+                types,
+                discriminator,
+            } => {
+                let arr: Vec<JsonValue> = types
                     .iter()
-                    .map(SchemaValueType::to_json)
-                    .collect::<Vec<JsonValue>>();
-                serde_json::json!({ "ARRAY": types })
+                    .map(|t| t.to_json(discriminator.as_deref()))
+                    .collect();
+                let mut obj = serde_json::Map::new();
+                obj.insert("ARRAY".into(), JsonValue::Array(arr));
+                if let Some(d) = discriminator {
+                    obj.insert("discriminator".into(), JsonValue::String(d.clone()));
+                }
+                JsonValue::Object(obj)
             }
-            SchemaValueType::Object(schema) => schema.to_json(),
+            SchemaValueType::Object(schema) => schema.to_json_with_hint(inherited_discriminator),
         }
     }
 }
@@ -96,7 +132,6 @@ impl<T: Eq + Hash> BoundedSet<T> {
         }
     }
 
-    /// Returns the underlying set if the threshold was never exceeded.
     fn within_threshold(&self) -> Option<&HashSet<T>> {
         if self.capped {
             None
@@ -111,6 +146,9 @@ struct KeyEntry {
     types: Vec<SchemaValueType>,
     seen_count: usize,
     values: Option<Vec<JsonValue>>,
+    /// Set when `types` contains 2+ Object variants and one of their fields
+    /// uniquely discriminates them.
+    discriminator: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -141,11 +179,7 @@ impl Schema {
             .collect()
     }
 
-    fn create_map(
-        objects: Vec<SchemaObject>,
-        merge_objects: bool,
-        enum_threshold: usize,
-    ) -> HashMap<String, KeyEntry> {
+    fn create_map(objects: Vec<SchemaObject>, config: &Config) -> HashMap<String, KeyEntry> {
         let mut types_map = HashMap::<String, Vec<SchemaValueType>>::new();
         let mut seen_counts = HashMap::<String, usize>::new();
         let mut string_lens = HashMap::<String, Vec<usize>>::new();
@@ -185,11 +219,8 @@ impl Schema {
                                     let entry = array_primitive_types_map
                                         .entry(key.id.clone())
                                         .or_default();
-                                    let vtype = SchemaValueType::from_value_type(
-                                        primitive_type,
-                                        merge_objects,
-                                        enum_threshold,
-                                    );
+                                    let vtype =
+                                        SchemaValueType::from_value_type(primitive_type, config);
                                     if !entry.contains(&vtype) {
                                         entry.push(vtype);
                                     }
@@ -202,7 +233,7 @@ impl Schema {
                         string_values
                             .entry(key.id.clone())
                             .or_insert_with(BoundedSet::new)
-                            .insert(value.clone(), enum_threshold);
+                            .insert(value.clone(), config.enum_threshold);
                     }
                     ValueType::Number(num) => {
                         let entry = types_map.entry(key.id.clone()).or_default();
@@ -213,15 +244,11 @@ impl Schema {
                         number_values
                             .entry(key.id.clone())
                             .or_insert_with(BoundedSet::new)
-                            .insert(num.clone(), enum_threshold);
+                            .insert(num.clone(), config.enum_threshold);
                     }
                     primitive_type => {
                         let entry = types_map.entry(key.id.clone()).or_default();
-                        let vtype = SchemaValueType::from_value_type(
-                            primitive_type,
-                            merge_objects,
-                            enum_threshold,
-                        );
+                        let vtype = SchemaValueType::from_value_type(primitive_type, config);
                         if !entry.contains(&vtype) {
                             entry.push(vtype);
                         }
@@ -240,15 +267,11 @@ impl Schema {
         }
 
         for (key, value) in object_types {
-            if merge_objects {
+            if config.merge_objects {
                 types_map
                     .entry(key)
                     .or_default()
-                    .push(SchemaValueType::Object(Schema::from_objects(
-                        value,
-                        true,
-                        enum_threshold,
-                    )));
+                    .push(SchemaValueType::Object(Schema::from_objects(value, config)));
             } else {
                 for objects_group in Self::group_objects_by_keys_fingerprint(value) {
                     types_map
@@ -256,8 +279,7 @@ impl Schema {
                         .or_default()
                         .push(SchemaValueType::Object(Schema::from_objects(
                             objects_group,
-                            false,
-                            enum_threshold,
+                            config,
                         )));
                 }
             }
@@ -274,18 +296,12 @@ impl Schema {
 
         for key in array_keys {
             let mut all_array_types: Vec<SchemaValueType> = match array_object_types.remove(&key) {
-                Some(value) if merge_objects => {
-                    vec![SchemaValueType::Object(Schema::from_objects(
-                        value,
-                        true,
-                        enum_threshold,
-                    ))]
+                Some(value) if config.merge_objects => {
+                    vec![SchemaValueType::Object(Schema::from_objects(value, config))]
                 }
                 Some(value) => Self::group_objects_by_keys_fingerprint(value)
                     .into_iter()
-                    .map(|group| {
-                        SchemaValueType::Object(Schema::from_objects(group, false, enum_threshold))
-                    })
+                    .map(|group| SchemaValueType::Object(Schema::from_objects(group, config)))
                     .collect(),
                 None => Vec::new(),
             };
@@ -298,10 +314,14 @@ impl Schema {
                 let max = *string_lens.iter().max().unwrap();
                 all_array_types.push(SchemaValueType::String(min, max));
             }
+            let array_discriminator = compute_discriminator(&all_array_types, config);
             types_map
                 .entry(key)
                 .or_default()
-                .push(SchemaValueType::Array(all_array_types));
+                .push(SchemaValueType::Array {
+                    types: all_array_types,
+                    discriminator: array_discriminator,
+                });
         }
 
         types_map
@@ -310,36 +330,42 @@ impl Schema {
                 let seen_count = seen_counts.remove(&key).unwrap_or(0);
                 let values =
                     enum_values_for_key(&types, string_values.get(&key), number_values.get(&key));
+                let discriminator = compute_discriminator(&types, config);
                 (
                     key,
                     KeyEntry {
                         types,
                         seen_count,
                         values,
+                        discriminator,
                     },
                 )
             })
             .collect()
     }
 
-    fn from_objects(
-        objects: Vec<SchemaObject>,
-        merge_objects: bool,
-        enum_threshold: usize,
-    ) -> Self {
+    fn from_objects(objects: Vec<SchemaObject>, config: &Config) -> Self {
         let parent_count = objects.len();
         Self {
             parent_count,
-            map: Self::create_map(objects, merge_objects, enum_threshold),
+            map: Self::create_map(objects, config),
         }
     }
 
     pub fn to_json(&self) -> JsonValue {
+        self.to_json_with_hint(None)
+    }
+
+    fn to_json_with_hint(&self, inherited_discriminator: Option<&str>) -> JsonValue {
         let mut map = serde_json::Map::new();
 
         for (key, entry) in &self.map {
             let mut out = serde_json::Map::new();
-            let types: Vec<JsonValue> = entry.types.iter().map(SchemaValueType::to_json).collect();
+            let types: Vec<JsonValue> = entry
+                .types
+                .iter()
+                .map(|t| t.to_json(entry.discriminator.as_deref()))
+                .collect();
             out.insert("types".into(), JsonValue::Array(types));
             if entry.seen_count < self.parent_count {
                 out.insert("optional".into(), JsonValue::Bool(true));
@@ -347,19 +373,24 @@ impl Schema {
             if let Some(values) = &entry.values {
                 out.insert("values".into(), JsonValue::Array(values.clone()));
             }
+            if let Some(d) = &entry.discriminator {
+                out.insert("discriminator".into(), JsonValue::String(d.clone()));
+            }
+            // If the enclosing union picked THIS key as its discriminator, mark it.
+            // This may overwrite the per-key field-level "discriminator" string set
+            // above — but only on a leaf scalar, where no inner union exists.
+            if Some(key.as_str()) == inherited_discriminator {
+                out.insert("discriminator".into(), JsonValue::Bool(true));
+            }
             map.insert(key.clone(), JsonValue::Object(out));
         }
 
         JsonValue::Object(map)
     }
 
-    pub fn from_json(json: &JsonValue, merge_objects: bool, enum_threshold: usize) -> Self {
+    pub fn from_json(json: &JsonValue, config: &Config) -> Self {
         match json {
-            JsonValue::Object(_) => Self::from_objects(
-                vec![SchemaObject::from_json(json)],
-                merge_objects,
-                enum_threshold,
-            ),
+            JsonValue::Object(_) => Self::from_objects(vec![SchemaObject::from_json(json)], config),
             JsonValue::Array(arr) => {
                 let objects = arr
                     .iter()
@@ -369,7 +400,7 @@ impl Schema {
                     })
                     .collect::<Vec<SchemaObject>>();
 
-                Self::from_objects(objects, merge_objects, enum_threshold)
+                Self::from_objects(objects, config)
             }
             _ => panic!("schermz expects the root JSON value to be an object or an array"),
         }
@@ -424,7 +455,6 @@ fn emit_string_values(set: &BoundedSet<String>) -> Option<Vec<JsonValue>> {
 fn emit_number_values(set: &BoundedSet<Number>) -> Option<Vec<JsonValue>> {
     let values = set.within_threshold()?;
     if !values.iter().all(|n| n.is_i64() || n.is_u64()) {
-        // Floats aren't useful as enum members.
         return None;
     }
     let mut sorted: Vec<&Number> = values.iter().collect();
@@ -439,4 +469,94 @@ fn emit_number_values(set: &BoundedSet<Number>) -> Option<Vec<JsonValue>> {
             .map(|n| JsonValue::Number(n.clone()))
             .collect(),
     )
+}
+
+/// Find a single field whose values uniquely identify each Object variant in
+/// `types`. Returns `None` if there are fewer than 2 Object variants, no field
+/// qualifies, or the union exceeds `discriminator_max_arms` arms.
+fn compute_discriminator(types: &[SchemaValueType], config: &Config) -> Option<String> {
+    let variants: Vec<&Schema> = types
+        .iter()
+        .filter_map(|t| match t {
+            SchemaValueType::Object(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+    if variants.len() < 2 {
+        return None;
+    }
+
+    // Step 1: fields present in every variant.
+    let mut common: Vec<&str> = variants[0].map.keys().map(String::as_str).collect();
+    common.retain(|f| variants[1..].iter().all(|v| v.map.contains_key(*f)));
+
+    // Step 2: present-and-required-and-has-values in every variant.
+    let with_values: Vec<&str> = common
+        .into_iter()
+        .filter(|f| {
+            variants.iter().all(|v| {
+                let entry = match v.map.get(*f) {
+                    Some(e) => e,
+                    None => return false,
+                };
+                entry.values.is_some() && entry.seen_count == v.parent_count
+            })
+        })
+        .collect();
+
+    // Step 3: pairwise-disjoint values across variants.
+    let disjoint: Vec<&str> = with_values
+        .into_iter()
+        .filter(|f| variant_values_pairwise_disjoint(&variants, f))
+        .collect();
+
+    // Step 4: total cardinality cap.
+    let mut survivors: Vec<(&str, usize)> = disjoint
+        .into_iter()
+        .filter_map(|f| {
+            let total: usize = variants
+                .iter()
+                .map(|v| v.map[f].values.as_ref().map(|vs| vs.len()).unwrap_or(0))
+                .sum();
+            if total <= config.discriminator_max_arms {
+                Some((f, total))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if !config.discriminator_fields.is_empty() {
+        // User-named priority list. Try each in order; first hit wins.
+        for user_field in &config.discriminator_fields {
+            if survivors.iter().any(|(f, _)| f == user_field) {
+                return Some(user_field.clone());
+            }
+        }
+        return None;
+    }
+
+    // Auto: smallest total cardinality, tie-break by name lexicographically.
+    survivors.sort_by(|a, b| a.1.cmp(&b.1).then(a.0.cmp(b.0)));
+    survivors.first().map(|(f, _)| (*f).to_string())
+}
+
+fn variant_values_pairwise_disjoint(variants: &[&Schema], field: &str) -> bool {
+    let value_sets: Vec<&[JsonValue]> = variants
+        .iter()
+        .map(|v| {
+            v.map[field]
+                .values
+                .as_deref()
+                .expect("checked Some in caller")
+        })
+        .collect();
+    for i in 0..value_sets.len() {
+        for j in (i + 1)..value_sets.len() {
+            if value_sets[i].iter().any(|v| value_sets[j].contains(v)) {
+                return false;
+            }
+        }
+    }
+    true
 }

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_detected_for_two_disjoint_variants.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_detected_for_two_disjoint_variants.snap
@@ -1,0 +1,62 @@
+---
+source: src/schema/tests.rs
+assertion_line: 544
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "premium": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                100
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(6)"
+              ],
+              "values": [
+                "opened"
+              ]
+            }
+          },
+          {
+            "paidDate": {
+              "types": [
+                "STRING(10)"
+              ],
+              "values": [
+                "2026-01-01"
+              ]
+            },
+            "premium": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                100
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(8)"
+              ],
+              "values": [
+                "in_force"
+              ]
+            }
+          }
+        ],
+        "discriminator": "status"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_fields_no_match_emits_nothing.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_fields_no_match_emits_nothing.snap
@@ -1,0 +1,51 @@
+---
+source: src/schema/tests.rs
+assertion_line: 696
+expression: "Schema::from_json(&json, &config).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "extra1": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(6)"
+              ],
+              "values": [
+                "opened"
+              ]
+            }
+          },
+          {
+            "extra2": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(8)"
+              ],
+              "values": [
+                "in_force"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_fields_override_picks_named_field.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_fields_override_picks_named_field.snap
@@ -1,0 +1,70 @@
+---
+source: src/schema/tests.rs
+assertion_line: 663
+expression: "Schema::from_json(&json, &config).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "extra1": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "kind": {
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "a"
+              ]
+            },
+            "tag": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "x"
+              ]
+            }
+          },
+          {
+            "extra2": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            },
+            "kind": {
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "b"
+              ]
+            },
+            "tag": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "y"
+              ]
+            }
+          }
+        ],
+        "discriminator": "tag"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_fields_priority_list_picks_first_match.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_fields_priority_list_picks_first_match.snap
@@ -1,0 +1,54 @@
+---
+source: src/schema/tests.rs
+assertion_line: 679
+expression: "Schema::from_json(&json, &config).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "extra1": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "a"
+              ]
+            }
+          },
+          {
+            "extra2": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            },
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "b"
+              ]
+            }
+          }
+        ],
+        "discriminator": "kind"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_lifeware_style_5_variants.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_lifeware_style_5_variants.snap
@@ -1,0 +1,151 @@
+---
+source: src/schema/tests.rs
+assertion_line: 713
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "additionalPayments": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "amount": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                100
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(7)"
+              ],
+              "values": [
+                "applied"
+              ]
+            }
+          },
+          {
+            "amount": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                200
+              ]
+            },
+            "openedAt": {
+              "types": [
+                "STRING(10)"
+              ],
+              "values": [
+                "2026-01-01"
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(6)"
+              ],
+              "values": [
+                "opened"
+              ]
+            }
+          },
+          {
+            "amount": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                200
+              ]
+            },
+            "openedAt": {
+              "types": [
+                "STRING(10)"
+              ],
+              "values": [
+                "2026-01-01"
+              ]
+            },
+            "paidDate": {
+              "types": [
+                "STRING(10)"
+              ],
+              "values": [
+                "2026-01-10"
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(8)"
+              ],
+              "values": [
+                "in_force"
+              ]
+            }
+          },
+          {
+            "amount": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                0
+              ]
+            },
+            "revokedAt": {
+              "types": [
+                "STRING(10)"
+              ],
+              "values": [
+                "2026-01-15"
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(7)"
+              ],
+              "values": [
+                "revoked"
+              ]
+            }
+          },
+          {
+            "amount": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                0
+              ]
+            },
+            "reason": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "kyc"
+              ]
+            },
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(8)"
+              ],
+              "values": [
+                "rejected"
+              ]
+            }
+          }
+        ],
+        "discriminator": "status"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_max_arms_raised_admits_more_variants.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_max_arms_raised_admits_more_variants.snap
@@ -1,0 +1,352 @@
+---
+source: src/schema/tests.rs
+assertion_line: 608
+expression: "Schema::from_json(&json, &config).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v0"
+              ]
+            },
+            "only_in_v0": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v1"
+              ]
+            },
+            "only_in_v1": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v2"
+              ]
+            },
+            "only_in_v2": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v3"
+              ]
+            },
+            "only_in_v3": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v4"
+              ]
+            },
+            "only_in_v4": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v5"
+              ]
+            },
+            "only_in_v5": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v6"
+              ]
+            },
+            "only_in_v6": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v7"
+              ]
+            },
+            "only_in_v7": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v8"
+              ]
+            },
+            "only_in_v8": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v9"
+              ]
+            },
+            "only_in_v9": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v10"
+              ]
+            },
+            "only_in_v10": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v11"
+              ]
+            },
+            "only_in_v11": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v12"
+              ]
+            },
+            "only_in_v12": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v13"
+              ]
+            },
+            "only_in_v13": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v14"
+              ]
+            },
+            "only_in_v14": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v15"
+              ]
+            },
+            "only_in_v15": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v16"
+              ]
+            },
+            "only_in_v16": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v17"
+              ]
+            },
+            "only_in_v17": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v18"
+              ]
+            },
+            "only_in_v18": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v19"
+              ]
+            },
+            "only_in_v19": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "discriminator": true,
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v20"
+              ]
+            },
+            "only_in_v20": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          }
+        ],
+        "discriminator": "id"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_picks_smaller_cardinality_then_alphabetical.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_picks_smaller_cardinality_then_alphabetical.snap
@@ -1,0 +1,100 @@
+---
+source: src/schema/tests.rs
+assertion_line: 575
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "extra": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "a"
+              ]
+            },
+            "tag": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "x1",
+                "x2"
+              ]
+            }
+          },
+          {
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "b"
+              ]
+            },
+            "other": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "tag": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "y1",
+                "y2"
+              ]
+            }
+          },
+          {
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "c"
+              ]
+            },
+            "more": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "tag": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "z1",
+                "z2"
+              ]
+            }
+          }
+        ],
+        "discriminator": "kind"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_for_field_not_in_every_variant.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_for_field_not_in_every_variant.snap
@@ -1,0 +1,62 @@
+---
+source: src/schema/tests.rs
+assertion_line: 645
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(6)"
+              ],
+              "values": [
+                "opened"
+              ]
+            },
+            "tag": {
+              "types": [
+                "STRING(5)"
+              ],
+              "values": [
+                "alpha"
+              ]
+            },
+            "v": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            }
+          },
+          {
+            "status": {
+              "discriminator": true,
+              "types": [
+                "STRING(8)"
+              ],
+              "values": [
+                "in_force"
+              ]
+            },
+            "v": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            }
+          }
+        ],
+        "discriminator": "status"
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_for_single_variant.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_for_single_variant.snap
@@ -1,0 +1,34 @@
+---
+source: src/schema/tests.rs
+assertion_line: 620
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "status": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "ok"
+              ]
+            },
+            "v": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1,
+                2
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_when_above_max_arms_cap.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_when_above_max_arms_cap.snap
@@ -1,0 +1,330 @@
+---
+source: src/schema/tests.rs
+assertion_line: 590
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v0"
+              ]
+            },
+            "only_in_v0": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v1"
+              ]
+            },
+            "only_in_v1": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v2"
+              ]
+            },
+            "only_in_v2": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v3"
+              ]
+            },
+            "only_in_v3": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v4"
+              ]
+            },
+            "only_in_v4": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v5"
+              ]
+            },
+            "only_in_v5": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v6"
+              ]
+            },
+            "only_in_v6": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v7"
+              ]
+            },
+            "only_in_v7": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v8"
+              ]
+            },
+            "only_in_v8": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "v9"
+              ]
+            },
+            "only_in_v9": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v10"
+              ]
+            },
+            "only_in_v10": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v11"
+              ]
+            },
+            "only_in_v11": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v12"
+              ]
+            },
+            "only_in_v12": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v13"
+              ]
+            },
+            "only_in_v13": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v14"
+              ]
+            },
+            "only_in_v14": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v15"
+              ]
+            },
+            "only_in_v15": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v16"
+              ]
+            },
+            "only_in_v16": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v17"
+              ]
+            },
+            "only_in_v17": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v18"
+              ]
+            },
+            "only_in_v18": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v19"
+              ]
+            },
+            "only_in_v19": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          },
+          {
+            "id": {
+              "types": [
+                "STRING(3)"
+              ],
+              "values": [
+                "v20"
+              ]
+            },
+            "only_in_v20": {
+              "types": [
+                "BOOL"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_when_values_overlap.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_when_values_overlap.snap
@@ -1,0 +1,69 @@
+---
+source: src/schema/tests.rs
+assertion_line: 557
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "a": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(4)"
+              ],
+              "values": [
+                "open"
+              ]
+            }
+          },
+          {
+            "b": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(4)"
+              ],
+              "values": [
+                "open"
+              ]
+            }
+          },
+          {
+            "a": {
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                3
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(6)"
+              ],
+              "values": [
+                "closed"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_with_merge_objects.snap
+++ b/src/schema/snapshots/schermz__schema__tests__discriminator_skipped_with_merge_objects.snap
@@ -1,0 +1,44 @@
+---
+source: src/schema/tests.rs
+assertion_line: 632
+expression: "Schema::from_json(&json, &merged_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "a": {
+              "optional": true,
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                1
+              ]
+            },
+            "b": {
+              "optional": true,
+              "types": [
+                "NUMBER"
+              ],
+              "values": [
+                2
+              ]
+            },
+            "status": {
+              "types": [
+                "STRING(6, 8)"
+              ],
+              "values": [
+                "in_force",
+                "opened"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__schema_from_array_unmerged.snap
+++ b/src/schema/snapshots/schermz__schema__tests__schema_from_array_unmerged.snap
@@ -1,14 +1,16 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 312
-expression: "Schema::from_json(&json, false, 30).to_json()"
+assertion_line: 330
+expression: "Schema::from_json(&json, &default_config()).to_json()"
 ---
 {
   "address": {
+    "discriminator": "city",
     "types": [
       "NULL",
       {
         "city": {
+          "discriminator": true,
           "types": [
             "STRING(6)"
           ],
@@ -43,6 +45,7 @@ expression: "Schema::from_json(&json, false, 30).to_json()"
       },
       {
         "city": {
+          "discriminator": true,
           "types": [
             "STRING(8)"
           ],
@@ -93,6 +96,7 @@ expression: "Schema::from_json(&json, false, 30).to_json()"
       },
       {
         "city": {
+          "discriminator": true,
           "types": [
             "STRING(7)"
           ],
@@ -193,6 +197,7 @@ expression: "Schema::from_json(&json, false, 30).to_json()"
         "ARRAY": [
           {
             "mobile": {
+              "discriminator": true,
               "types": [
                 "STRING(10, 11)"
               ],
@@ -212,6 +217,7 @@ expression: "Schema::from_json(&json, false, 30).to_json()"
               ]
             },
             "mobile": {
+              "discriminator": true,
               "types": [
                 "STRING(13)"
               ],
@@ -222,7 +228,8 @@ expression: "Schema::from_json(&json, false, 30).to_json()"
           },
           "NUMBER",
           "STRING(10, 17)"
-        ]
+        ],
+        "discriminator": "mobile"
       }
     ]
   },

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -1,52 +1,70 @@
 use super::*;
 
+fn default_config() -> Config {
+    Config::default()
+}
+
+fn merged_config() -> Config {
+    Config {
+        merge_objects: true,
+        ..Config::default()
+    }
+}
+
+fn config_with_enum_threshold(threshold: usize) -> Config {
+    Config {
+        enum_threshold: threshold,
+        ..Config::default()
+    }
+}
+
 #[test]
 #[should_panic]
 fn root_null_panics() {
-    Schema::from_json(&serde_json::Value::Null, false, 30);
+    Schema::from_json(&serde_json::Value::Null, &default_config());
 }
 
 #[test]
 #[should_panic]
 fn root_string_panics() {
-    Schema::from_json(&serde_json::json!("hello"), false, 30);
+    Schema::from_json(&serde_json::json!("hello"), &default_config());
 }
 
 #[test]
 #[should_panic]
 fn root_number_panics() {
-    Schema::from_json(&serde_json::json!(42), false, 30);
+    Schema::from_json(&serde_json::json!(42), &default_config());
 }
 
 #[test]
 #[should_panic]
 fn root_bool_panics() {
-    Schema::from_json(&serde_json::json!(true), false, 30);
+    Schema::from_json(&serde_json::json!(true), &default_config());
 }
 
 #[test]
 fn empty_root_object() {
     let json = serde_json::json!({});
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
 fn empty_root_array() {
     let json = serde_json::json!([]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
 fn root_array_with_only_primitives_is_empty() {
     // The CLI ignores non-object elements at the root array level.
     let json = serde_json::json!([1, "hello", null, true]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
 fn bool_values() {
     let json = serde_json::json!({ "active": true, "verified": false });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -55,7 +73,7 @@ fn empty_nested_object_and_array() {
         "empty_obj": {},
         "empty_arr": []
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -63,7 +81,7 @@ fn deeply_nested_objects() {
     let json = serde_json::json!({
         "a": { "b": { "c": { "d": { "value": "deep" } } } }
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -71,7 +89,7 @@ fn array_of_primitives_only() {
     let json = serde_json::json!({
         "tags": [1, 2, "three", "four", null, true]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -82,7 +100,7 @@ fn nested_arrays_with_strings() {
     let json = serde_json::json!({
         "matrix": [["a", "bb"], ["ccc"]]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -92,7 +110,7 @@ fn merged_strings_collapse_min_max() {
         { "name": "abcd" },
         { "name": "abc" }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -101,7 +119,7 @@ fn unmerged_keeps_distinct_object_shapes() {
         { "info": { "a": 1 } },
         { "info": { "a": 1, "b": 2 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -110,7 +128,7 @@ fn merged_collapses_distinct_object_shapes() {
         { "info": { "a": 1 } },
         { "info": { "a": 1, "b": 2 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -131,7 +149,7 @@ fn test_schema_from_object() {
         ]
     });
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -220,7 +238,7 @@ fn test_schema_from_array_merged() {
         }
     ]);
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -309,7 +327,7 @@ fn test_schema_from_array_unmerged() {
         }
     ]);
 
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 // ---------- Feature 1: optionality tracking ----------
@@ -322,14 +340,14 @@ fn optional_top_level_key_in_array() {
         { "a": 2, "b": 20 },
         { "a": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
 fn single_object_input_never_marks_optional() {
     // Sample size of 1 -> we can't infer optionality.
     let json = serde_json::json!({ "a": 1, "b": 2 });
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -341,7 +359,7 @@ fn nested_object_optional_uses_correct_denominator() {
         { "addr": { "x": 1 } },
         { "other": 1 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -352,7 +370,7 @@ fn unmerged_variants_have_no_optional_within() {
         { "addr": { "x": 1, "y": 2 } },
         { "addr": { "x": 1 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -365,7 +383,7 @@ fn array_of_objects_optional_field() {
             { "a": 2, "b": 20 }
         ]
     });
-    insta::assert_json_snapshot!(Schema::from_json(&json, true, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
 }
 
 #[test]
@@ -377,7 +395,7 @@ fn null_value_counts_as_present() {
         { "x": null },
         { "y": 7 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -388,7 +406,7 @@ fn type_variation_alone_is_not_optionality() {
         { "id": "two" },
         { "id": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 // ---------- Feature 2: enum value extraction ----------
@@ -400,7 +418,7 @@ fn string_enum_two_distinct_values_emitted_sorted() {
         { "status": "opened" },
         { "status": "in_force" }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -411,7 +429,7 @@ fn string_enum_over_threshold_skipped() {
         items.push(serde_json::json!({ "k": format!("v{i}") }));
     }
     let json = serde_json::Value::Array(items);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -422,13 +440,17 @@ fn custom_threshold_admits_more_values() {
         items.push(serde_json::json!({ "k": format!("v{i}") }));
     }
     let json = serde_json::Value::Array(items);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 100).to_json());
+    insta::assert_json_snapshot!(
+        Schema::from_json(&json, &config_with_enum_threshold(100)).to_json()
+    );
 }
 
 #[test]
 fn threshold_zero_disables_values_entirely() {
     let json = serde_json::json!([{ "k": "a" }, { "k": "b" }]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 0).to_json());
+    insta::assert_json_snapshot!(
+        Schema::from_json(&json, &config_with_enum_threshold(0)).to_json()
+    );
 }
 
 #[test]
@@ -439,7 +461,7 @@ fn mixed_string_and_number_skips_values() {
         { "id": 1 },
         { "id": "b" }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -450,7 +472,7 @@ fn long_strings_skip_values_even_below_threshold() {
         { "blob": "small" },
         { "blob": big }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -462,7 +484,7 @@ fn integer_only_numbers_emit_values_sorted_numerically() {
         { "code": 2 },
         { "code": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -473,7 +495,7 @@ fn float_numbers_skip_values() {
         { "price": 2.5 },
         { "price": 3 }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -485,7 +507,7 @@ fn bool_only_field_skips_values() {
         { "active": false },
         { "active": true }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -497,7 +519,7 @@ fn string_with_null_still_emits_values() {
         { "tag": null },
         { "tag": "b" }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
 
 #[test]
@@ -507,5 +529,190 @@ fn string_with_object_skips_values() {
         { "thing": "hello" },
         { "thing": { "nested": 1 } }
     ]);
-    insta::assert_json_snapshot!(Schema::from_json(&json, false, 30).to_json());
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+// ---------- Feature 3: discriminator detection ----------
+
+#[test]
+fn discriminator_detected_for_two_disjoint_variants() {
+    // Classic tagged union: status partitions the two shapes cleanly. Premium
+    // is shared (100 in both variants) so it can't be a discriminator and
+    // status is the only qualifying field.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "opened", "premium": 100 },
+            { "status": "in_force", "premium": 100, "paidDate": "2026-01-01" }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_skipped_when_values_overlap() {
+    // status="open" appears in both variants -> disjointness fails.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "open", "a": 1 },
+            { "status": "open", "b": 2 },
+            { "status": "closed", "a": 3 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_picks_smaller_cardinality_then_alphabetical() {
+    // Both `kind` and `tag` discriminate cleanly. `kind` has total cardinality 3
+    // (1+1+1), `tag` has 6 (2+2+2) -> pick `kind`. Then if both had cardinality
+    // 3, alphabetical tie-break would pick `kind` over `tag` anyway.
+    let json = serde_json::json!({
+        "items": [
+            { "kind": "a", "tag": "x1", "extra": 1 },
+            { "kind": "a", "tag": "x2", "extra": 1 },
+            { "kind": "b", "tag": "y1", "other": 1 },
+            { "kind": "b", "tag": "y2", "other": 1 },
+            { "kind": "c", "tag": "z1", "more": 1 },
+            { "kind": "c", "tag": "z2", "more": 1 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_skipped_when_above_max_arms_cap() {
+    // 21 distinct id values across 21 variants -> over the default cap of 20.
+    let mut items = Vec::new();
+    for i in 0..21 {
+        items.push(serde_json::json!({
+            "id": format!("v{i}"),
+            // make each variant structurally distinct so they don't merge
+            format!("only_in_v{i}"): true
+        }));
+    }
+    let json = serde_json::json!({ "items": items });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_max_arms_raised_admits_more_variants() {
+    // Same 21 variants, max-arms raised to 50 -> discriminator emitted.
+    let mut items = Vec::new();
+    for i in 0..21 {
+        items.push(serde_json::json!({
+            "id": format!("v{i}"),
+            format!("only_in_v{i}"): true
+        }));
+    }
+    let json = serde_json::json!({ "items": items });
+    let config = Config {
+        discriminator_max_arms: 50,
+        ..Config::default()
+    };
+    insta::assert_json_snapshot!(Schema::from_json(&json, &config).to_json());
+}
+
+#[test]
+fn discriminator_skipped_for_single_variant() {
+    // One Object variant, no union to discriminate.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "ok", "v": 1 },
+            { "status": "ok", "v": 2 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_skipped_with_merge_objects() {
+    // -m collapses to a single shape, so there's nothing to discriminate.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "opened", "a": 1 },
+            { "status": "in_force", "b": 2 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &merged_config()).to_json());
+}
+
+#[test]
+fn discriminator_skipped_for_field_not_in_every_variant() {
+    // `tag` is in variant 1 only -> not a candidate. `status` is in both and
+    // disjoint, so it wins.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "opened", "tag": "alpha", "v": 1 },
+            { "status": "in_force", "v": 2 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn discriminator_fields_override_picks_named_field() {
+    // Auto-pick would be `kind` alphabetically; user override forces `tag`.
+    // Each variant has a distinct extra key so the variants don't collapse
+    // into one shape.
+    let json = serde_json::json!({
+        "items": [
+            { "kind": "a", "tag": "x", "extra1": 1 },
+            { "kind": "b", "tag": "y", "extra2": 2 }
+        ]
+    });
+    let config = Config {
+        discriminator_fields: vec!["tag".into()],
+        ..Config::default()
+    };
+    insta::assert_json_snapshot!(Schema::from_json(&json, &config).to_json());
+}
+
+#[test]
+fn discriminator_fields_priority_list_picks_first_match() {
+    // User lists [foo, kind]. foo doesn't exist; kind qualifies -> kind wins.
+    let json = serde_json::json!({
+        "items": [
+            { "kind": "a", "extra1": 1 },
+            { "kind": "b", "extra2": 2 }
+        ]
+    });
+    let config = Config {
+        discriminator_fields: vec!["foo".into(), "kind".into()],
+        ..Config::default()
+    };
+    insta::assert_json_snapshot!(Schema::from_json(&json, &config).to_json());
+}
+
+#[test]
+fn discriminator_fields_no_match_emits_nothing() {
+    // User restricts to fields that don't qualify -> no discriminator at all,
+    // even if other fields would have qualified for auto-detection.
+    let json = serde_json::json!({
+        "items": [
+            { "status": "opened", "extra1": 1 },
+            { "status": "in_force", "extra2": 2 }
+        ]
+    });
+    let config = Config {
+        discriminator_fields: vec!["nonexistent".into()],
+        ..Config::default()
+    };
+    insta::assert_json_snapshot!(Schema::from_json(&json, &config).to_json());
+}
+
+#[test]
+fn discriminator_lifeware_style_5_variants() {
+    // Approximates Lifeware's additionalPayments shape: 5 variants discriminated
+    // by `status` alone (the spec mentions a composite status+invested case;
+    // this single-field version is what the v1 algorithm handles).
+    let json = serde_json::json!({
+        "additionalPayments": [
+            { "status": "applied", "amount": 100 },
+            { "status": "opened", "amount": 200, "openedAt": "2026-01-01" },
+            { "status": "in_force", "amount": 200, "paidDate": "2026-01-10", "openedAt": "2026-01-01" },
+            { "status": "revoked", "amount": 0, "revokedAt": "2026-01-15" },
+            { "status": "rejected", "amount": 0, "reason": "kyc" }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }


### PR DESCRIPTION
Third and final feature PR. **Stacked on #136 (optionality) and #137 (enum values)** — base will narrow once those merge.

## What

When a key's `types` (or an array's element list) contains 2+ distinct object shapes, schermz now scans for a single field whose values uniquely identify each variant.

```json
{
  "additionalPayments": {
    "types": [
      {
        "ARRAY": [
          { "status": { "types": ["STRING(6)"], "values": ["opened"], "discriminator": true }, ... },
          { "status": { "types": ["STRING(8)"], "values": ["in_force"], "discriminator": true }, ... }
        ],
        "discriminator": "status"
      }
    ]
  }
}
```

This is what downstream codegen needs for `z.discriminatedUnion("status", [...])` instead of plain `z.union([...])`.

## Algorithm

A field qualifies when:
- It exists in every variant.
- It has a `"values"` enum set in every variant (consumes feature 2's output).
- Its values are pairwise disjoint across variants.
- It's not optional in any variant.
- Total distinct values across all variants ≤ `--discriminator-max-arms` (default 20).

Among qualifying fields: pick the smallest total cardinality, tie-break by name lexicographically. With `-m`, variants are pre-collapsed, so this analysis never fires.

## New flags

- `--discriminator-max-arms <N>` — cap, default `20`.
- `--discriminator-fields a,b,c` — priority list. When set, only these fields are considered (in order); first qualifying one wins, no auto fallback. **Escape hatch** for the coincidental-disjointness case (e.g. a numeric `amount` whose values happen to differ across variants and gets picked over the real `status`).

## Refactors in this PR

- `Schema::from_json` now takes a `Config` struct (bundling all four knobs). Tests use `Config::default()` with overrides. The previous incremental signature was getting unwieldy and feature 3 added two more knobs.
- `SchemaValueType::Array` changes from tuple to struct variant carrying `discriminator: Option<String>`.
- `to_json` threads an `inherited_discriminator` hint through nested Schemas so each variant can mark its discriminating key.

## Snapshot deltas

The existing `test_schema_from_array_unmerged` fixture picks up discriminators on `address` (`city`) and `phones[]` (`mobile`) — both **coincidental disjointnesses** in the test data, not real semantic discriminators. The README calls this out as a known limitation alongside the `--discriminator-fields` override.

## Tests added (13)

- 2-variant clean detection
- Overlapping values → rejected
- Smaller cardinality wins; alphabetical tie-break
- Max-arms cap; cap can be raised
- Single variant → no discriminator
- `-m` set → no discriminator
- Field not in every variant → not a candidate
- `--discriminator-fields` override picks named field
- Priority list: first-qualifying wins
- No-match user list → no discriminator (no auto fallback)
- Lifeware-style 5-variant fixture (`additionalPayments`)

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 48 passing (was 36)
- [x] CLI smoke test on a small union; verified auto-pick + override

## Known limitations (documented in README)

- **Coincidental disjointness** can produce false positives when an unrelated field happens to have unique values per variant. Use `--discriminator-fields` to override.
- **Composite discriminators** are not detected. If your real discriminator is `(status, invested)` together but neither alone is sufficient, schermz returns no discriminator. Hand-pick one with `--discriminator-fields` for a partial answer.

## Stack

Sits on #136 → #137 → this PR. Once #136 merges, #137's diff narrows; once #137 merges, this PR's diff narrows to just feature 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)