### PR TITLE
fix: fold non-consecutive same-shape objects into one variant

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,9 +5,8 @@ mod tests;
 
 use itertools::Itertools;
 use serde_json::{Number, Value as JsonValue};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 use value_type::{SchemaObject, ValueType};
 
@@ -161,22 +160,22 @@ type CollectedObjects = HashMap<String, Vec<SchemaObject>>;
 
 impl Schema {
     fn group_objects_by_keys_fingerprint(objects: Vec<SchemaObject>) -> Vec<Vec<SchemaObject>> {
-        objects
-            .into_iter()
-            .chunk_by(|obj| {
-                let mut hasher = DefaultHasher::new();
-                let sorted_keys = obj
-                    .keys
-                    .iter()
-                    .map(|obj_key| obj_key.id.as_str())
-                    .sorted()
-                    .collect::<Vec<_>>();
-                sorted_keys.join("").hash(&mut hasher);
-                hasher.finish()
-            })
-            .into_iter()
-            .map(|(_, gr)| gr.collect_vec())
-            .collect()
+        // Fold objects with the same key set into the same group regardless of
+        // their position. Ordering is by first occurrence, so deterministic and
+        // source-order-friendly for snapshot tests.
+        let mut groups: Vec<Vec<SchemaObject>> = Vec::new();
+        let mut fp_to_idx: HashMap<String, usize> = HashMap::new();
+
+        for obj in objects {
+            let fp = key_fingerprint(&obj);
+            if let Some(&idx) = fp_to_idx.get(&fp) {
+                groups[idx].push(obj);
+            } else {
+                fp_to_idx.insert(fp, groups.len());
+                groups.push(vec![obj]);
+            }
+        }
+        groups
     }
 
     fn create_map(objects: Vec<SchemaObject>, config: &Config) -> HashMap<String, KeyEntry> {
@@ -405,6 +404,19 @@ impl Schema {
             _ => panic!("schermz expects the root JSON value to be an object or an array"),
         }
     }
+}
+
+/// Stable identity for an object's key set. Used to fold structurally
+/// identical objects into the same variant during unmerged grouping.
+fn key_fingerprint(obj: &SchemaObject) -> String {
+    obj.keys
+        .iter()
+        .map(|k| k.id.as_str())
+        .sorted()
+        .collect::<Vec<_>>()
+        // U+001E (record separator) keeps `["ab", "c"]` and `["a", "bc"]`
+        // distinct without colliding with anything that turns up in JSON keys.
+        .join("\u{001e}")
 }
 
 /// Decide whether a key's distinct scalar values should be emitted as a

--- a/src/schema/snapshots/schermz__schema__tests__same_shape_high_cardinality_id_drops_values_keeps_low_card.snap
+++ b/src/schema/snapshots/schermz__schema__tests__same_shape_high_cardinality_id_drops_values_keeps_low_card.snap
@@ -1,0 +1,32 @@
+---
+source: src/schema/tests.rs
+assertion_line: 770
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "items": {
+    "types": [
+      {
+        "ARRAY": [
+          {
+            "bucket": {
+              "types": [
+                "STRING(4, 5)"
+              ],
+              "values": [
+                "alpha",
+                "beta",
+                "gamma"
+              ]
+            },
+            "id": {
+              "types": [
+                "STRING(9)"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_merges_for_nested_objects.snap
+++ b/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_merges_for_nested_objects.snap
@@ -1,0 +1,42 @@
+---
+source: src/schema/tests.rs
+assertion_line: 783
+expression: "Schema::from_json(&json, &default_config()).to_json()"
+---
+{
+  "inner": {
+    "types": [
+      {
+        "a": {
+          "types": [
+            "NUMBER"
+          ],
+          "values": [
+            1,
+            3
+          ]
+        }
+      },
+      {
+        "a": {
+          "types": [
+            "NUMBER"
+          ],
+          "values": [
+            1,
+            4
+          ]
+        },
+        "b": {
+          "types": [
+            "NUMBER"
+          ],
+          "values": [
+            2,
+            5
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_merges_into_one_variant.snap
+++ b/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_merges_into_one_variant.snap
@@ -1,6 +1,6 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 561
+assertion_line: 736
 expression: "Schema::from_json(&json, &default_config()).to_json()"
 ---
 {
@@ -9,44 +9,57 @@ expression: "Schema::from_json(&json, &default_config()).to_json()"
       {
         "ARRAY": [
           {
-            "a": {
+            "id": {
+              "types": [
+                "STRING(2)"
+              ],
+              "values": [
+                "a1",
+                "a2",
+                "a3"
+              ]
+            },
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "x"
+              ]
+            }
+          },
+          {
+            "extra": {
               "types": [
                 "NUMBER"
               ],
               "values": [
                 1,
-                3
-              ]
-            },
-            "status": {
-              "types": [
-                "STRING(4, 6)"
-              ],
-              "values": [
-                "closed",
-                "open"
-              ]
-            }
-          },
-          {
-            "b": {
-              "types": [
-                "NUMBER"
-              ],
-              "values": [
                 2
               ]
             },
-            "status": {
+            "id": {
               "types": [
-                "STRING(4)"
+                "STRING(2)"
               ],
               "values": [
-                "open"
+                "b1",
+                "b2"
+              ]
+            },
+            "kind": {
+              "discriminator": true,
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "y"
               ]
             }
           }
-        ]
+        ],
+        "discriminator": "kind"
       }
     ]
   }

--- a/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_unions_value_sets.snap
+++ b/src/schema/snapshots/schermz__schema__tests__same_shape_non_consecutive_unions_value_sets.snap
@@ -1,6 +1,6 @@
 ---
 source: src/schema/tests.rs
-assertion_line: 561
+assertion_line: 752
 expression: "Schema::from_json(&json, &default_config()).to_json()"
 ---
 {
@@ -9,40 +9,34 @@ expression: "Schema::from_json(&json, &default_config()).to_json()"
       {
         "ARRAY": [
           {
-            "a": {
+            "id": {
+              "types": [
+                "STRING(1)"
+              ],
+              "values": [
+                "a",
+                "b",
+                "c"
+              ]
+            },
+            "n": {
               "types": [
                 "NUMBER"
               ],
               "values": [
                 1,
+                2,
                 3
-              ]
-            },
-            "status": {
-              "types": [
-                "STRING(4, 6)"
-              ],
-              "values": [
-                "closed",
-                "open"
               ]
             }
           },
           {
-            "b": {
+            "kind": {
               "types": [
-                "NUMBER"
+                "STRING(15)"
               ],
               "values": [
-                2
-              ]
-            },
-            "status": {
-              "types": [
-                "STRING(4)"
-              ],
-              "values": [
-                "open"
+                "different shape"
               ]
             }
           }

--- a/src/schema/tests.rs
+++ b/src/schema/tests.rs
@@ -716,3 +716,69 @@ fn discriminator_lifeware_style_5_variants() {
     });
     insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
 }
+
+// ---------- Variant grouping fix: same shape, non-consecutive ----------
+
+#[test]
+fn same_shape_non_consecutive_merges_into_one_variant() {
+    // Three structurally-identical {id, kind} objects interleaved with two
+    // {id, kind, extra} objects. Used to fragment into 5 variants because the
+    // grouping was based on `chunk_by` (consecutive items only). Now folds to 2.
+    let json = serde_json::json!({
+        "items": [
+            { "id": "a1", "kind": "x" },
+            { "id": "b1", "kind": "y", "extra": 1 },
+            { "id": "a2", "kind": "x" },
+            { "id": "b2", "kind": "y", "extra": 2 },
+            { "id": "a3", "kind": "x" }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn same_shape_non_consecutive_unions_value_sets() {
+    // Same-shape objects that disagree on every scalar value still merge into
+    // one variant; their distinct values union into a single `values` list.
+    let json = serde_json::json!({
+        "items": [
+            { "id": "a", "n": 1 },
+            { "kind": "different shape" },
+            { "id": "b", "n": 2 },
+            { "kind": "different shape" },
+            { "id": "c", "n": 3 }
+        ]
+    });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn same_shape_high_cardinality_id_drops_values_keeps_low_card() {
+    // 1000 same-shape objects with unique `id` strings (over default threshold
+    // of 30 -> id values dropped) but a low-cardinality `bucket` field that
+    // should still surface a complete merged value set.
+    let mut items = Vec::new();
+    let buckets = ["alpha", "beta", "gamma"];
+    for i in 0..1000 {
+        let bucket = buckets[i % 3];
+        items.push(serde_json::json!({
+            "id": format!("uuid-{i:04}"),
+            "bucket": bucket,
+        }));
+    }
+    let json = serde_json::json!({ "items": items });
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}
+
+#[test]
+fn same_shape_non_consecutive_merges_for_nested_objects() {
+    // The grouping fix has to apply at every level of recursion. Here `inner`
+    // is a nested object with two distinct shapes interleaved across parents.
+    let json = serde_json::json!([
+        { "inner": { "a": 1 } },
+        { "inner": { "a": 1, "b": 2 } },
+        { "inner": { "a": 3 } },
+        { "inner": { "a": 4, "b": 5 } }
+    ]);
+    insta::assert_json_snapshot!(Schema::from_json(&json, &default_config()).to_json());
+}


### PR DESCRIPTION
Fixes the regression you hit on the large fixture (16k-line output, 1,743 \"variants\" for what should have been a handful).

## Diagnosis

The agent's hint pointed at a values-equality issue from feature 2, but the actual cause is older: `Schema::group_objects_by_keys_fingerprint` used `itertools::chunk_by`, which only groups **consecutive** same-fingerprint items. On real-world input where same-shape objects are scattered through the source array (most production data), it fragments each shape into many tiny \"variants\" instead of one.

The bug has been in the codebase since the original implementation. Features 2 and 3 made it dramatically more visible:
- Feature 2 made each fragment emit its own per-fragment `values` list, ballooning output.
- Feature 3 then ran discriminator analysis over that fragmented list, often picking coincidentally-disjoint fields.

The values-tracking code itself is correct — it accumulates per-key, not per-variant — and there is no PartialEq impl that compares value sets. The fix is in the grouping pass.

## Fix

Replace the `chunk_by` call with a fold that hashes each object's sorted-key fingerprint and folds it into the matching bucket regardless of position. Output order is by first occurrence, so any existing test where shapes were already non-overlapping and consecutive is unchanged. The fingerprint uses U+001E (record separator) as the key delimiter to avoid collisions like `[\"ab\", \"c\"]` vs `[\"a\", \"bc\"]`.

## Snapshot impact

One existing test (`discriminator_skipped_when_values_overlap`) had three objects with key sets `[F1, F2, F1]` — those two `F1` objects now correctly merge into one variant. Test name and intent still apply: the merged variant's `status` values still overlap variant 2's, disjointness still fails, no discriminator is emitted.

## New tests (4)

- 5 objects, two shapes interleaved → 2 variants, values correctly unioned
- Nested-object variant grouping (recursive case)
- Same-shape across other-shape interruptions still merges
- **1000 same-shape rows** with unique high-cardinality `id` (drops `values`) and 3-value `bucket` (keeps `values`) → exactly one variant. This is the case you hit.

## Expected impact on your data

Your 16k-line / 1,743-variant output should collapse to whatever the actual structurally-distinct shape count is — probably ~5 (status-driven) for `additionalPayments`. Re-`cargo install --path .` from this branch to test.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 52 passing (was 48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)